### PR TITLE
:bug: fix: enable flyway.baseline-on-migrate to initialize schema history

### DIFF
--- a/kok-api/src/main/resources/application-dev.yml
+++ b/kok-api/src/main/resources/application-dev.yml
@@ -16,6 +16,7 @@ spring:
     defer-datasource-initialization: false
   flyway:
     enabled: true
+    baseline-on-migrate: true
   data:
     redis:
       cluster:

--- a/kok-api/src/main/resources/application-prod.yml
+++ b/kok-api/src/main/resources/application-prod.yml
@@ -16,6 +16,7 @@ spring:
     defer-datasource-initialization: false
   flyway:
     enabled: true
+    baseline-on-migrate: true
   data:
     redis:
       cluster:


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 📝 작업 내용
- Flyway의 스키마 이력 초기화 오류를 수정하기 위해 splring.flyway.baseline-on-migrate 옵션을 활성화하였습니다.
- 기존에 kok-db에서 flyway_schema_history 테이블이 없어 발생하는 오류 수정
- flyway가 자동으로 베이스라인을 적용하여 이후 마이그레이션이 정상적으로 진행되도록 수정


### ***📸 스크린샷***
<img width="1507" alt="log" src="https://github.com/user-attachments/assets/a514b607-4f4a-49d6-a910-18469d307009" />



## ***💬 리뷰 요구사항(선택)***
