### PR TITLE
:recycle: [Refactor/BaseController] Replace BaseController with annotion

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/rest/LocationController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/rest/LocationController.java
@@ -1,11 +1,11 @@
 package com.kok.kokapi.centroid.adapter.in.rest;
 
-import com.kok.kokapi.common.adapter.in.web.BaseController;
 import com.kok.kokapi.centroid.adapter.in.dto.LocationRequest;
 import com.kok.kokapi.centroid.adapter.out.dto.CentroidResponse;
 import com.kok.kokapi.centroid.adapter.out.dto.LocationResponse;
 import com.kok.kokapi.centroid.adapter.out.mapper.LocationMapper;
 import com.kok.kokapi.common.response.ApiResponseDto;
+import com.kok.kokapi.config.annotion.V1Controller;
 import com.kok.kokcore.location.domain.Location;
 import com.kok.kokcore.location.usecase.CreateLocationUsecase;
 import com.kok.kokcore.location.usecase.ReadCentroidUsecase;
@@ -20,9 +20,9 @@ import org.springframework.web.bind.annotation.*;
 import java.math.BigDecimal;
 import java.util.List;
 
-@RestController
+@V1Controller
 @RequiredArgsConstructor
-public class LocationController extends BaseController {
+public class LocationController {
 
     private final CreateLocationUsecase createLocationUsecase;
     private final ReadCentroidUsecase readCentroidUsecase;

--- a/kok-api/src/main/java/com/kok/kokapi/common/adapter/in/web/BaseController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/common/adapter/in/web/BaseController.java
@@ -1,7 +1,0 @@
-package com.kok.kokapi.common.adapter.in.web;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-
-@RequestMapping("/v1/api")
-public abstract class BaseController {
-}

--- a/kok-api/src/main/java/com/kok/kokapi/config/annotion/V1Controller.java
+++ b/kok-api/src/main/java/com/kok/kokapi/config/annotion/V1Controller.java
@@ -1,0 +1,16 @@
+package com.kok.kokapi.config.annotion;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@RestController
+@RequestMapping("/v1/api")
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface V1Controller {
+}

--- a/kok-api/src/main/java/com/kok/kokapi/monitoring/adapter/in/web/HealthCheckController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/monitoring/adapter/in/web/HealthCheckController.java
@@ -1,15 +1,14 @@
 package com.kok.kokapi.monitoring.adapter.in.web;
 
+import com.kok.kokapi.config.annotion.V1Controller;
 import com.kok.kokapi.monitoring.application.service.HealthCheckService;
-import com.kok.kokapi.common.adapter.in.web.BaseController;
 import com.kok.kokapi.common.response.ApiResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@V1Controller
 @RequiredArgsConstructor
-public class HealthCheckController extends BaseController {
+public class HealthCheckController {
 
     private final HealthCheckService healthCheckService;
 

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/web/RoomController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/web/RoomController.java
@@ -1,7 +1,7 @@
 package com.kok.kokapi.room.adapter.in.web;
 
-import com.kok.kokapi.common.adapter.in.web.BaseController;
 import com.kok.kokapi.common.response.ApiResponseDto;
+import com.kok.kokapi.config.annotion.V1Controller;
 import com.kok.kokapi.room.adapter.in.dto.request.CreateRoomRequest;
 import com.kok.kokapi.room.adapter.in.dto.request.JoinRoomParticipantRequest;
 import com.kok.kokapi.room.adapter.in.dto.response.RoomMembersResponse;
@@ -20,9 +20,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RestController
+@V1Controller
 @RequiredArgsConstructor
-public class RoomController extends BaseController {
+public class RoomController {
 
     private final GetRoomUseCase getRoomUseCase;
     private final CreateRoomUseCase createRoomUseCase;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #

## 📝 작업 내용
BaseController 상속 방식을 제거하고 `@V1Controller` 애노테이션을 적용하여 API 버전 관리를 개선하였습니다.

변경사항
- `@V1Controller` 애노테이션을 추가하여 API 버전 관리 일원화
- 컨트롤러의 중복된 `@RestController` 설정 제거
- 버전 관리를 용이하게 하기 위한 목적이므로 의미가 명확하지 않은 기존 BaseController 제거 및 관련 코드 정리


### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
