### PR TITLE
🐛 [Fix/station-normalization] normalize station table

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
@@ -4,6 +4,7 @@ import com.kok.kokapi.station.adapter.out.external.dto.StationResponses;
 import com.kok.kokcore.station.application.port.out.LoadStationsPort;
 import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 import java.util.StringJoiner;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
@@ -11,6 +12,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @EnableConfigurationProperties(StationClientProperties.class)
 public class StationClient implements LoadStationsPort {
@@ -43,6 +45,10 @@ public class StationClient implements LoadStationsPort {
             .uri(getTargetUri())
             .retrieve()
             .body(StationResponses.class);
+        log.info("Seoul Data Open API Status Code: {}, Message: {}",
+            responses.subwayStationMaster().result().code(),
+            responses.subwayStationMaster().result().message()
+        );
         return responses.toStationRouteDtos();
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
@@ -2,8 +2,7 @@ package com.kok.kokapi.station.adapter.out.external;
 
 import com.kok.kokapi.station.adapter.out.external.dto.StationResponses;
 import com.kok.kokcore.station.application.port.out.LoadStationsPort;
-import com.kok.kokcore.station.domain.entity.Station;
-import java.util.List;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 import java.util.StringJoiner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
@@ -39,12 +38,12 @@ public class StationClient implements LoadStationsPort {
     }
 
     @Override
-    public List<Station> loadAllStations() {
+    public StationRouteDtos loadAllStations() {
         StationResponses responses = restClient.get()
             .uri(getTargetUri())
             .retrieve()
             .body(StationResponses.class);
-        return responses.toStations();
+        return responses.toStationRouteDtos();
     }
 
     public String getTargetUri() {

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
@@ -45,7 +45,7 @@ public class StationClient implements LoadStationsPort {
             .uri(getTargetUri())
             .retrieve()
             .body(StationResponses.class);
-        log.info("Seoul Data Open API Status Code: {}, Message: {}",
+        log.debug("Seoul Data Open API Status Code: {}, Message: {}",
             responses.subwayStationMaster().result().code(),
             responses.subwayStationMaster().result().message()
         );

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationClient.java
@@ -21,9 +21,11 @@ public class StationClient implements LoadStationsPort {
 
     private final RestClient restClient;
     private final StationClientProperties properties;
+    private final StationErrorHandler stationErrorHandler;
 
-    public StationClient(StationClientProperties properties) {
+    public StationClient(StationClientProperties properties, StationErrorHandler stationErrorHandler) {
         this.properties = properties;
+        this.stationErrorHandler = stationErrorHandler;
         this.restClient = getRestClient();
     }
 
@@ -31,6 +33,7 @@ public class StationClient implements LoadStationsPort {
         return RestClient.builder()
             .requestFactory(getRequestFactory())
             .baseUrl(properties.baseUrl())
+            .defaultStatusHandler(stationErrorHandler)
             .build();
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationErrorHandler.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/StationErrorHandler.java
@@ -1,0 +1,34 @@
+package com.kok.kokapi.station.adapter.out.external;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kok.kokapi.station.adapter.out.external.dto.StationResponses;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+@Component
+@RequiredArgsConstructor
+public class StationErrorHandler implements ResponseErrorHandler {
+
+    private static final List<String> SERVER_ERROR = List.of("ERROR-500", "ERROR-600", "ERROR-601");
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        String code = objectMapper.readValue(response.getBody(), StationResponses.class)
+            .subwayStationMaster()
+            .result()
+            .code();
+        return SERVER_ERROR.contains(code);
+    }
+
+    @Override
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+        throw new RuntimeException("서버 오류입니다. 지속적으로 발생시 열린 데이터 광장으로 문의(Q&A) 바랍니다.");
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/dto/StationResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/dto/StationResponse.java
@@ -1,7 +1,7 @@
 package com.kok.kokapi.station.adapter.out.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.kok.kokcore.station.domain.entity.Station;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDto;
 
 public record StationResponse(
     @JsonProperty("BLDN_ID")
@@ -16,7 +16,7 @@ public record StationResponse(
     String longitude
 ) {
 
-    public Station toStation() {
-        return new Station(id, name, route, latitude, longitude);
+    public StationRouteDto toStationRouteDto() {
+        return new StationRouteDto(name, latitude, longitude, id, route);
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/dto/StationResponses.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/external/dto/StationResponses.java
@@ -1,17 +1,16 @@
 package com.kok.kokapi.station.adapter.out.external.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.kok.kokcore.station.domain.entity.Station;
-import java.util.List;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 
 public record StationResponses(
     @JsonProperty("subwayStationMaster")
     SubwayStationMaster subwayStationMaster
 ) {
 
-    public List<Station> toStations() {
-        return subwayStationMaster.row().stream()
-            .map(StationResponse::toStation)
-            .toList();
+    public StationRouteDtos toStationRouteDtos() {
+        return new StationRouteDtos(subwayStationMaster.row().stream()
+            .map(StationResponse::toStationRouteDto)
+            .toList());
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
@@ -1,0 +1,54 @@
+package com.kok.kokapi.station.adapter.out.persistence;
+
+import com.kok.kokcore.station.application.port.out.SaveRoutePort;
+import com.kok.kokcore.station.domain.entity.Route;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RoutePersistenceAdapter implements SaveRoutePort {
+    private static final String INSERT_ROUTE_SQL = """
+            INSERT INTO route (code, name, station_id)
+            VALUES(?, ?, ?)
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveRoutes(List<Route> routes) {
+        if (routes.isEmpty()) {
+            log.info("No routes to save.");
+            return;
+        }
+        batchInsertRoutes(routes);
+    }
+
+    private void batchInsertRoutes(List<Route> routes) {
+        int[] batches = jdbcTemplate.batchUpdate(INSERT_ROUTE_SQL,
+            new BatchPreparedStatementSetter() {
+                @Override
+                public void setValues(PreparedStatement ps, int i) throws SQLException {
+                    Route route = routes.get(i);
+                    ps.setLong(1, route.getCode());
+                    ps.setString(2, route.getName());
+                    ps.setLong(3, route.getStation().getId());
+                }
+
+                @Override
+                public int getBatchSize() {
+                    return routes.size();
+                }
+            });
+        log.info("Successfully saved a total of {} routes out of {}.",
+            Arrays.stream(batches).sum(), routes.size());
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
@@ -32,7 +32,7 @@ public class RoutePersistenceAdapter implements SaveRoutePort {
     @Override
     public void saveRoutes(List<Route> routes) {
         if (routes.isEmpty()) {
-            log.info("No routes to save.");
+            log.debug("No routes to save.");
             return;
         }
         batchInsertRoutes(routes);
@@ -49,6 +49,6 @@ public class RoutePersistenceAdapter implements SaveRoutePort {
                 savedCount++;
             }
         }
-        log.info("Successfully saved a total of {} routes out of {}.", savedCount, routes.size());
+        log.debug("Successfully saved a total of {} routes out of {}.", savedCount, routes.size());
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/RoutePersistenceAdapter.java
@@ -10,9 +10,9 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-@Component
+@Repository
 @Slf4j
 @RequiredArgsConstructor
 public class RoutePersistenceAdapter implements SaveRoutePort {

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -11,9 +11,9 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-@Component
+@Repository
 @Slf4j
 @RequiredArgsConstructor
 public class StationPersistenceAdapter implements SaveStationsPort, ReadStationsPort {

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -22,7 +22,7 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
 
     private static final String INSERT_STATION_SQL = """
             INSERT INTO station (name, latitude, longitude, priority)
-            VALUES (?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?)
         """;
     private static final String INSERT_ROUTE_SQL = """
             INSERT INTO ROUTE (code, route, station_id)

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -35,7 +35,7 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
     @Override
     public List<Station> saveStations(List<Station> stations) {
         if (stations.isEmpty()) {
-            log.info("No stations to save.");
+            log.debug("No stations to save.");
             return List.of();
         }
         return batchInsertStations(stations);
@@ -51,7 +51,7 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
                 savedCount++;
             }
         }
-        log.info("Successfully saved a total of {} stations out of {}.", savedCount, stations.size());
+        log.debug("Successfully saved a total of {} stations out of {}.", savedCount, stations.size());
         return stationRepository.findAll();
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -3,7 +3,9 @@ package com.kok.kokapi.station.adapter.out.persistence;
 import com.kok.kokcore.station.application.port.out.ReadStationsPort;
 import com.kok.kokcore.station.application.port.out.SaveStationsPort;
 import com.kok.kokcore.station.domain.entity.Station;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,17 +44,17 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
     }
 
     private List<Station> batchInsertStations(List<Station> stations) {
-        int savedCount = 0;
+        List<Long> savedStationIds = new ArrayList<>();
         for (Station station : stations) {
             MapSqlParameterSource parameters = mapToParams.apply(station);
             KeyHolder keyHolder = new GeneratedKeyHolder();
-            int updateCount = jdbcTemplate.update(INSERT_STATION_SQL, parameters, keyHolder, new String[]{"id"});
-            if (updateCount > 0) {
-                savedCount++;
+            jdbcTemplate.update(INSERT_STATION_SQL, parameters, keyHolder, new String[]{"id"});
+            if(Objects.nonNull(keyHolder.getKey())){
+                savedStationIds.add(keyHolder.getKey().longValue());
             }
         }
-        log.debug("Successfully saved a total of {} stations out of {}.", savedCount, stations.size());
-        return stationRepository.findAll();
+        log.debug("Successfully saved a total of {} stations out of {}.", savedStationIds.size(), stations.size());
+        return stationRepository.findAllById(savedStationIds);
     }
 
     @Override
@@ -60,3 +62,4 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
         return !stationRepository.existsAny();
     }
 }
+

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -25,7 +25,7 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
             VALUES (?, ?, ?, ?)
         """;
     private static final String INSERT_ROUTE_SQL = """
-            INSERT INTO ROUTE (code, route, station_id)
+            INSERT INTO route (code, name, station_id)
             VALUES(?, ?, ?)
         """;
 
@@ -73,7 +73,7 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
                 public void setValues(PreparedStatement ps, int i) throws SQLException {
                     Route route = routes.get(i);
                     ps.setLong(1, route.getCode());
-                    ps.setString(2, route.getRoute());
+                    ps.setString(2, route.getName());
                     ps.setLong(3, route.getStation().getId());
                 }
 

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapter.java
@@ -3,16 +3,12 @@ package com.kok.kokapi.station.adapter.out.persistence;
 import com.kok.kokcore.station.application.port.out.ReadStationsPort;
 import com.kok.kokcore.station.application.port.out.SaveStationsPort;
 import com.kok.kokcore.station.domain.entity.Station;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -44,17 +40,14 @@ public class StationPersistenceAdapter implements SaveStationsPort, ReadStations
     }
 
     private List<Station> batchInsertStations(List<Station> stations) {
-        List<Long> savedStationIds = new ArrayList<>();
-        for (Station station : stations) {
-            MapSqlParameterSource parameters = mapToParams.apply(station);
-            KeyHolder keyHolder = new GeneratedKeyHolder();
-            jdbcTemplate.update(INSERT_STATION_SQL, parameters, keyHolder, new String[]{"id"});
-            if(Objects.nonNull(keyHolder.getKey())){
-                savedStationIds.add(keyHolder.getKey().longValue());
-            }
-        }
-        log.debug("Successfully saved a total of {} stations out of {}.", savedStationIds.size(), stations.size());
-        return stationRepository.findAllById(savedStationIds);
+        MapSqlParameterSource[] batchParams = stations.stream()
+            .map(mapToParams)
+            .toArray(MapSqlParameterSource[]::new);
+        int[] batched = jdbcTemplate.batchUpdate(INSERT_STATION_SQL, batchParams);
+        log.debug("Successfully saved a total of {} stations out of {}.", batched.length,
+            stations.size());
+        List<String> names = stations.stream().map(Station::getName).toList();
+        return stationRepository.findAllByNameIn(names);
     }
 
     @Override

--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationRepository.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/out/persistence/StationRepository.java
@@ -1,6 +1,7 @@
 package com.kok.kokapi.station.adapter.out.persistence;
 
 import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -8,4 +9,6 @@ public interface StationRepository extends JpaRepository<Station, Long> {
 
     @Query("SELECT EXISTS (SELECT 1 FROM Station)")
     boolean existsAny();
+
+    List<Station> findAllByNameIn(List<String> names);
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/application/config/StationsConfig.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/application/config/StationsConfig.java
@@ -4,19 +4,12 @@ import com.kok.kokapi.station.application.service.StationService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 public class StationsConfig {
 
     @Bean
     CommandLineRunner initStations(StationService stationService) {
-        return new CommandLineRunner() {
-            @Override
-            @Transactional
-            public void run(String... args) {
-                stationService.saveStations();
-            }
-        };
+        return args -> stationService.saveStations();
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/application/service/StationService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/application/service/StationService.java
@@ -3,9 +3,8 @@ package com.kok.kokapi.station.application.service;
 import com.kok.kokcore.station.application.port.out.LoadStationsPort;
 import com.kok.kokcore.station.application.port.out.ReadStationsPort;
 import com.kok.kokcore.station.application.port.out.SaveStationsPort;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 import com.kok.kokcore.station.application.usecase.SaveStationUseCase;
-import com.kok.kokcore.station.domain.entity.Station;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,13 +20,9 @@ public class StationService implements SaveStationUseCase {
     @Override
     @Transactional
     public void saveStations() {
-        if(hasNoStations()) {
-            List<Station> stations = loadStationsPort.loadAllStations();
+        if(readStationsPort.hasNoStations()) {
+            StationRouteDtos stations = loadStationsPort.loadAllStations();
             saveStationsPort.saveStations(stations);
         }
-    }
-
-    private boolean hasNoStations() {
-        return readStationsPort.hasNoStations();
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/station/application/service/StationService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/application/service/StationService.java
@@ -2,9 +2,12 @@ package com.kok.kokapi.station.application.service;
 
 import com.kok.kokcore.station.application.port.out.LoadStationsPort;
 import com.kok.kokcore.station.application.port.out.ReadStationsPort;
+import com.kok.kokcore.station.application.port.out.SaveRoutePort;
 import com.kok.kokcore.station.application.port.out.SaveStationsPort;
 import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 import com.kok.kokcore.station.application.usecase.SaveStationUseCase;
+import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,13 +19,15 @@ public class StationService implements SaveStationUseCase {
     private final LoadStationsPort loadStationsPort;
     private final SaveStationsPort saveStationsPort;
     private final ReadStationsPort readStationsPort;
+    private final SaveRoutePort saveRoutePort;
 
     @Override
     @Transactional
     public void saveStations() {
         if(readStationsPort.hasNoStations()) {
-            StationRouteDtos stations = loadStationsPort.loadAllStations();
-            saveStationsPort.saveStations(stations);
+            StationRouteDtos stationRouteDtos = loadStationsPort.loadAllStations();
+            List<Station> stations = saveStationsPort.saveStations(stationRouteDtos.toStations());
+            saveRoutePort.saveRoutes(stationRouteDtos.toRoutesByStations(stations));
         }
     }
 }

--- a/kok-api/src/main/resources/application-dev.yml
+++ b/kok-api/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/kok-api/src/main/resources/db/V1__init_station.sql
+++ b/kok-api/src/main/resources/db/V1__init_station.sql
@@ -1,17 +1,29 @@
-CREATE TABLE station (
-                         id BIGINT NOT NULL AUTO_INCREMENT,
-                         name VARCHAR(20) NOT NULL,
-                         latitude DECIMAL(16, 14) NOT NULL,
-                         longitude DECIMAL(17, 14) NOT NULL,
-                         priority BIGINT NOT NULL,
-                         PRIMARY KEY (id)
-);
+CREATE TABLE station
+(
+    id        BIGINT          NOT NULL AUTO_INCREMENT,
+    name      VARCHAR(20)     NOT NULL,
+    latitude  DECIMAL(16, 14) NOT NULL,
+    longitude DECIMAL(17, 14) NOT NULL,
+    priority  BIGINT          NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE route (
-                       id BIGINT NOT NULL AUTO_INCREMENT,
-                       code BIGINT NOT NULL,
-                       station_id BIGINT NOT NULL,
-                       name VARCHAR(20) NOT NULL,
-                       PRIMARY KEY (id),
-                       FOREIGN KEY (station_id) REFERENCES station(id)
+CREATE TABLE route
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    code       BIGINT      NOT NULL,
+    station_id BIGINT      NOT NULL,
+    name       VARCHAR(20) NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (station_id) REFERENCES station (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+create table location
+(
+    id        bigint auto_increment primary key,
+    member_id int          not null,
+    point     point        not null,
+    uuid      varchar(255) not null,
+    constraint UKrgpajb4rsivb4gj9xn2qowgw6
+        unique (uuid, member_id)
 );

--- a/kok-api/src/main/resources/db/V1__init_station.sql
+++ b/kok-api/src/main/resources/db/V1__init_station.sql
@@ -1,11 +1,17 @@
-CREATE TABLE station
-(
-    id         BIGINT          NOT NULL AUTO_INCREMENT,
-    station_id BIGINT          NOT NULL,
-    name       VARCHAR(255)    NOT NULL,
-    route      VARCHAR(255)    NOT NULL,
-    latitude   DECIMAL(16, 14) NOT NULL,
-    longitude  DECIMAL(17, 14) NOT NULL,
-    priority BIGINT NOT NULL,
-    PRIMARY KEY (id)
+CREATE TABLE station (
+                         id BIGINT NOT NULL AUTO_INCREMENT,
+                         name VARCHAR(20) NOT NULL,
+                         latitude DECIMAL(16, 14) NOT NULL,
+                         longitude DECIMAL(17, 14) NOT NULL,
+                         priority BIGINT NOT NULL,
+                         PRIMARY KEY (id)
+);
+
+CREATE TABLE route (
+                       id BIGINT NOT NULL AUTO_INCREMENT,
+                       code BIGINT NOT NULL,
+                       station_id BIGINT NOT NULL,
+                       name VARCHAR(20) NOT NULL,
+                       PRIMARY KEY (id),
+                       FOREIGN KEY (station_id) REFERENCES station(id)
 );

--- a/kok-api/src/test/java/com/kok/kokapi/common/template/ContainerBaseTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/common/template/ContainerBaseTest.java
@@ -9,13 +9,12 @@ public abstract class ContainerBaseTest {
 
     private static final int REDIS_PORT = 6379;
 
-    private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0")
-        .withDatabaseName("kok")
+    private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.4")
+        .withDatabaseName("kok-db")
         .withUsername("root")
         .withPassword("1234");
 
-    private static final RedisContainer redisContainer = new RedisContainer(
-        RedisContainer.DEFAULT_IMAGE_NAME.withTag(RedisContainer.DEFAULT_TAG)
+    private static final RedisContainer redisContainer = new RedisContainer("redis:7.0"
     );
 
     static {
@@ -32,5 +31,8 @@ public abstract class ContainerBaseTest {
 
         registry.add("spring.data.redis.host", redisContainer::getHost);
         registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("spring.flyway.baseline-on-migrate", () -> true);
     }
 }

--- a/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/external/FakeStationClient.java
+++ b/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/external/FakeStationClient.java
@@ -1,17 +1,19 @@
 package com.kok.kokapi.station.adapter.out.external;
 
 import com.kok.kokcore.station.application.port.out.LoadStationsPort;
-import com.kok.kokcore.station.domain.entity.Station;
-import java.math.BigDecimal;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDto;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 import java.util.List;
 
 public class FakeStationClient implements LoadStationsPort {
 
     @Override
-    public List<Station> loadAllStations() {
-        return List.of(
-            new Station(1L, "서울역", "1호선", BigDecimal.ONE, BigDecimal.ONE, 0),
-            new Station(2L, "합정역", "2호선", BigDecimal.TEN, BigDecimal.TEN, 5)
+    public StationRouteDtos loadAllStations() {
+        return new StationRouteDtos(
+            List.of(
+                new StationRouteDto("서울역", "1", "2", 1L, "1호선"),
+                new StationRouteDto("합정역", "10", "10", 2L, "2호선")
+            )
         );
     }
 }

--- a/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/persistence/StationPersistenceAdapterTest.java
@@ -1,0 +1,37 @@
+package com.kok.kokapi.station.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.kok.kokapi.common.template.ServiceTest;
+import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StationPersistenceAdapterTest extends ServiceTest {
+
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
+    private StationPersistenceAdapter stationPersistenceAdapter;
+
+    @DisplayName("새로 저장된 지하철 목록만 반환한다.")
+    @Test
+    void saveStationsAndReturn() {
+        // given
+        Station savedStation = new Station("망원역", "12.345","123.456");
+        List<Station> stations = List.of(new Station("합정역", "12.345","123.456"));
+        stationRepository.save(savedStation);
+
+        // when
+        List<Station> result = stationPersistenceAdapter.saveStations(stations);
+
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result.get(0).getName()).isEqualTo("합정역")
+        );
+    }
+}

--- a/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/persistence/StationRepositoryTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/station/adapter/out/persistence/StationRepositoryTest.java
@@ -18,7 +18,7 @@ class StationRepositoryTest extends RepositoryTest {
     @Test
     void existsAny() {
         // given
-        stationRepository.save(new Station(1L, "서울역", "1호선", BigDecimal.ONE, BigDecimal.ONE, 0));
+        stationRepository.save(new Station("서울역", BigDecimal.ONE, BigDecimal.ONE, 0));
 
         // when
         boolean result = stationRepository.existsAny();

--- a/kok-api/src/test/java/com/kok/kokapi/station/application/service/StationServiceTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/station/application/service/StationServiceTest.java
@@ -31,7 +31,7 @@ class StationServiceTest extends ServiceTest {
     @Test
     void doesNotSaveStationsIfAlreadyExists() {
         //given
-        stationRepository.save(new Station(1L, "서울역", "1호선", BigDecimal.ONE, BigDecimal.ONE, 0));
+        stationRepository.save(new Station("서울역", BigDecimal.ONE, BigDecimal.ONE, 0));
 
         // when
         stationService.saveStations();

--- a/kok-api/src/test/resources/application-test.yml
+++ b/kok-api/src/test/resources/application-test.yml
@@ -1,18 +1,18 @@
 spring:
   profiles:
     active: test
-  sql:
-    init:
-      mode: always
   flyway:
     enabled: true
     connect-retries: 30
+    baseline-on-migrate: true
   jpa:
     show-sql: true
     properties:
       hibernate:
+        show_sql: true
         format_sql: true
+        dialect: org.hibernate.spatial.dialect.mysql.MySQLSpatialDialect
     defer-datasource-initialization: false
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/LoadStationsPort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/LoadStationsPort.java
@@ -1,9 +1,8 @@
 package com.kok.kokcore.station.application.port.out;
 
-import com.kok.kokcore.station.domain.entity.Station;
-import java.util.List;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 
 public interface LoadStationsPort {
 
-    List<Station> loadAllStations();
+    StationRouteDtos loadAllStations();
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveRoutePort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveRoutePort.java
@@ -1,0 +1,9 @@
+package com.kok.kokcore.station.application.port.out;
+
+import com.kok.kokcore.station.domain.entity.Route;
+import java.util.List;
+
+public interface SaveRoutePort {
+
+    void saveRoutes(List<Route> routes);
+}

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveStationsPort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveStationsPort.java
@@ -1,9 +1,8 @@
 package com.kok.kokcore.station.application.port.out;
 
-import com.kok.kokcore.station.domain.entity.Station;
-import java.util.List;
+import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
 
 public interface SaveStationsPort {
 
-    void saveStations(List<Station> stations);
+    void saveStations(StationRouteDtos stationRouteDtos);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveStationsPort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/SaveStationsPort.java
@@ -1,8 +1,9 @@
 package com.kok.kokcore.station.application.port.out;
 
-import com.kok.kokcore.station.application.port.out.dto.StationRouteDtos;
+import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
 
 public interface SaveStationsPort {
 
-    void saveStations(StationRouteDtos stationRouteDtos);
+    List<Station> saveStations(List<Station> stations);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDto.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDto.java
@@ -16,7 +16,7 @@ public record StationRouteDto(
     }
 
     public Station toStation() {
-        return new Station(name, longitude, longitude);
+        return new Station(name, latitude, longitude);
     }
 
     public Route toRouteByStation(Station station) {

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDto.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDto.java
@@ -1,0 +1,25 @@
+package com.kok.kokcore.station.application.port.out.dto;
+
+import com.kok.kokcore.station.domain.entity.Route;
+import com.kok.kokcore.station.domain.entity.Station;
+
+public record StationRouteDto(
+    String name,
+    String latitude,
+    String longitude,
+    Long stationId,
+    String route
+) {
+
+    public boolean hasName(Station station) {
+        return name.equals(station.getName());
+    }
+
+    public Station toStation() {
+        return new Station(name, longitude, longitude);
+    }
+
+    public Route toRouteByStation(Station station) {
+        return new Route(stationId, route, station);
+    }
+}

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
@@ -1,0 +1,19 @@
+package com.kok.kokcore.station.application.port.out.dto;
+
+import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
+
+public record StationRouteDtos(
+    List<StationRouteDto> stationRouteDtos
+) {
+
+    public boolean isEmpty() {
+        return stationRouteDtos().isEmpty();
+    }
+
+    public List<Station> toStations() {
+        return stationRouteDtos.stream()
+            .map(StationRouteDto::toStation)
+            .toList();
+    }
+}

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
@@ -4,6 +4,7 @@ import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record StationRouteDtos(
     List<StationRouteDto> stationRouteDtos
@@ -14,9 +15,19 @@ public record StationRouteDtos(
     }
 
     public List<Station> toStations() {
-        return stationRouteDtos.stream()
+        return distinctByName().stream()
             .map(StationRouteDto::toStation)
             .toList();
+    }
+
+    private List<StationRouteDto> distinctByName() {
+        return new ArrayList<>(stationRouteDtos.stream()
+            .collect(Collectors.toMap(
+                StationRouteDto::name,
+                dto -> dto,
+                (existing, replacement) -> existing
+            ))
+            .values());
     }
 
     public List<Route> toRoutesByStations(List<Station> stations){

--- a/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtos.java
@@ -1,6 +1,8 @@
 package com.kok.kokcore.station.application.port.out.dto;
 
+import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
+import java.util.ArrayList;
 import java.util.List;
 
 public record StationRouteDtos(
@@ -15,5 +17,17 @@ public record StationRouteDtos(
         return stationRouteDtos.stream()
             .map(StationRouteDto::toStation)
             .toList();
+    }
+
+    public List<Route> toRoutesByStations(List<Station> stations){
+        List<Route> routes = new ArrayList<>();
+        for (Station station : stations) {
+            List<Route> routesOfStation = stationRouteDtos.stream()
+                .filter(stationRouteDto -> stationRouteDto.hasName(station))
+                .map(stationRouteDto -> stationRouteDto.toRouteByStation(station))
+                .toList();
+            routes.addAll(routesOfStation);
+        }
+        return routes;
     }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
@@ -1,0 +1,36 @@
+package com.kok.kokcore.station.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Route {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private Long code;
+    @Column(nullable = false, length = 15)
+    private String route;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "station_id", nullable = false)
+    private Station station;
+
+    public Route(Long code, String route, Station station) {
+        this.code = code;
+        this.route = route;
+        this.station = station;
+    }
+}

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
@@ -22,7 +22,7 @@ public class Route {
     private Long id;
     @Column(nullable = false)
     private Long code;
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, length = 20)
     private String route;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "station_id", nullable = false)

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
@@ -23,14 +23,14 @@ public class Route {
     @Column(nullable = false)
     private Long code;
     @Column(nullable = false, length = 20)
-    private String route;
+    private String name;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "station_id", nullable = false)
     private Station station;
 
-    public Route(Long code, String route, Station station) {
+    public Route(Long code, String name, Station station) {
         this.code = code;
-        this.route = route;
+        this.name = name;
         this.station = station;
     }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Station.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Station.java
@@ -18,12 +18,8 @@ public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false)
-    private Long stationId;
-    @Column(nullable = false)
+    @Column(nullable = false, length = 15)
     private String name;
-    @Column(nullable = false)
-    private String route;
     @Column(nullable = false, columnDefinition = "DECIMAL(16, 14)")
     private BigDecimal latitude;
     @Column(nullable = false, columnDefinition = "DECIMAL(17, 14)")
@@ -31,26 +27,14 @@ public class Station {
     @Column(nullable = false)
     private Long priority;
 
-    public Station(Long id, Long stationId, String name, String route, BigDecimal latitude,
-        BigDecimal longitude) {
-        this.id = id;
-        this.stationId = stationId;
+    public Station(String name, BigDecimal latitude, BigDecimal longitude, long priority) {
         this.name = name;
-        this.route = route;
-        this.latitude = latitude;
-        this.longitude = longitude;
-    }
-
-    public Station(Long stationId, String name, String route, BigDecimal latitude, BigDecimal longitude, long priority) {
-        this.stationId = stationId;
-        this.name = name;
-        this.route = route;
         this.latitude = latitude;
         this.longitude = longitude;
         this.priority = priority;
     }
 
-    public Station(Long stationId, String name, String route, String latitude, String longitude) {
-        this(stationId, name, route, new BigDecimal(latitude),new BigDecimal(longitude), 0);
+    public Station(String name,String latitude, String longitude) {
+        this(name, new BigDecimal(latitude),new BigDecimal(longitude), 0);
     }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Station.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Station.java
@@ -18,7 +18,7 @@ public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, length = 20)
     private String name;
     @Column(nullable = false, columnDefinition = "DECIMAL(16, 14)")
     private BigDecimal latitude;

--- a/kok-core/src/test/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtosTest.java
+++ b/kok-core/src/test/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtosTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +39,6 @@ class StationRouteDtosTest {
         assertThat(result).isFalse();
     }
 
-    @Disabled
     @DisplayName("stationRouteDtos를 Station 리스트로 중복 없이 변환한다.")
     @Test
     void toStations() {

--- a/kok-core/src/test/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtosTest.java
+++ b/kok-core/src/test/java/com/kok/kokcore/station/application/port/out/dto/StationRouteDtosTest.java
@@ -1,0 +1,97 @@
+package com.kok.kokcore.station.application.port.out.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.kok.kokcore.station.domain.entity.Route;
+import com.kok.kokcore.station.domain.entity.Station;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StationRouteDtosTest {
+
+    @DisplayName("stationRouteDtos가 비어 있으면 참을 반환한다.")
+    @Test
+    void isEmpty() {
+        // given
+        StationRouteDtos stationRouteDtos = new StationRouteDtos(List.of());
+
+        // when
+        boolean result = stationRouteDtos.isEmpty();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("stationRouteDtos가 비어 있지 않으면 거짓을 반환한다.")
+    @Test
+    void isNotEmpty() {
+        // given
+        StationRouteDto stationRouteDto = new StationRouteDto("서울역", "37.556", "126.972", 1L,
+            "1호선");
+        StationRouteDtos stationRouteDtos = new StationRouteDtos(List.of(stationRouteDto));
+
+        // when
+        boolean result = stationRouteDtos.isEmpty();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Disabled
+    @DisplayName("stationRouteDtos를 Station 리스트로 중복 없이 변환한다.")
+    @Test
+    void toStations() {
+        // given
+        StationRouteDto stationRouteDto1 = new StationRouteDto("서울역", "37.556", "126.972", 1L,
+            "1호선");
+        StationRouteDto stationRouteDto2 = new StationRouteDto("강남역", "37.497", "127.028", 2L,
+            "2호선");
+        StationRouteDto stationRouteDto3 = new StationRouteDto("강남역", "37.496", "127.029", 3L, "신분당선");
+        StationRouteDtos stationRouteDtos = new StationRouteDtos(
+            List.of(stationRouteDto1, stationRouteDto2, stationRouteDto3)
+        );
+
+        // when
+        List<Station> stations = stationRouteDtos.toStations();
+
+        // then
+        List<String> names = stations.stream().map(Station::getName).toList();
+
+        assertAll(
+            () -> assertThat(stations).hasSize(2),
+            () -> assertThat(names).containsExactlyInAnyOrder("서울역", "강남역")
+        );
+    }
+
+    @DisplayName("stationRouteDtos를 Route 리스트로 변환한다.")
+    @Test
+    void toRoutesByStations() {
+        // given
+        StationRouteDto stationRouteDto1 = new StationRouteDto("서울역", "37.556", "126.972", 1L,
+            "1호선");
+        StationRouteDto stationRouteDto2 = new StationRouteDto("강남역", "37.497", "127.028", 2L,
+            "2호선");
+        StationRouteDto stationRouteDto3 = new StationRouteDto("강남역", "37.497", "127.028", 3L, "신분당선");
+        StationRouteDtos stationRouteDtos = new StationRouteDtos(
+            List.of(stationRouteDto1, stationRouteDto2, stationRouteDto3)
+        );
+        Station station1 = new Station("서울역", "37.556", "126.972");
+        Station station2 = new Station("강남역", "37.497", "127.028");
+
+        // when
+        List<Route> routes = stationRouteDtos.toRoutesByStations(List.of(station1, station2));
+
+        // then
+        List<Long> codes = routes.stream().map(Route::getCode).toList();
+        List<Station> stations = routes.stream().map(Route::getStation).distinct().toList();
+
+        assertAll(
+            () -> assertThat(routes).hasSize(3),
+            () -> assertThat(codes).containsExactlyInAnyOrder(1L, 2L, 3L),
+            () -> assertThat(stations).containsExactlyInAnyOrder(station1, station2)
+        );
+    }
+}


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
- #50 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- station entity와 route entity를 분리했습니다.
- 그 과정에서 open api로 불러온 데이터를 담을 dto가 필요했어요 (open api 호출 결과를 담는 response 객체는 api 모듈에 존재하기 때문에 core 모듈에서 api 모듈에 의존성을 가지지 않기 위해 `StationRouteDto` 개념이 추가되었어요!)
- Station은 이름을 기준으로 중복되지 않도록 추출하는 방식으로 구현했어요 (위도/경도에 대한 후처리는 하지 않았어요! 차이가 미미하기 때문에 처음으로 찾는 위도/경도 기준으로 저장합니다.)
- StationPersistenceAdapter에 의해 Station을 먼저 batch update 한 후 그 결과 값(List<Station>)을 가지고 route 정보를 저장하는 batch update를 수행했어요.

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
- 코드가 더러워요... 추가적으로 jdbcTemplate 부분은 NamedParameterJdbcTemplate을 사용하도록 리팩터링 했는데, 더 가독성 좋은 방법이 있다면 피드백 부탁드립니다~
- `List<Station> saveStationPort.saveStations()`에서 결과값을 반환하기 위해 keyHolder가 가진 ID 값으로 `station.setId(keyHolder.getXX())`을 하는 방법도 있었지만, ID에 대해서 setter를 열어두고 싶지 않아서 `stationRepository.findAll0`로 결과값을 조회하는 식으로 구현했어요. 더 좋은 방법이 있다면 피드백 부탁드려용