### PR TITLE
✨ [Feature/RoomParticipant] add boolean field if room is full for getting profile list

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/dto/response/RoomDetailResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/dto/response/RoomDetailResponse.java
@@ -5,20 +5,14 @@ import com.kok.kokcore.room.domain.Room;
 public record RoomDetailResponse(
     String id,
     String roomName,
-    int nonParticipantCount,
-    boolean isFulled
+    int nonParticipantCount
 ) {
 
     public static RoomDetailResponse of(Room room, int participantCount) {
         return new RoomDetailResponse(
             room.getId(),
             room.getRoomName(),
-            room.getCapacity() - participantCount,
-            isFulled(room, participantCount)
+            room.getCapacity() - participantCount
         );
-    }
-
-    private static boolean isFulled(Room room, int participantCount) {
-        return room.getCapacity() == participantCount;
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/dto/response/RoomMembersResponses.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/dto/response/RoomMembersResponses.java
@@ -1,0 +1,25 @@
+package com.kok.kokapi.room.adapter.in.dto.response;
+
+import com.kok.kokcore.room.domain.Member;
+import com.kok.kokcore.room.domain.Room;
+import java.util.List;
+
+public record RoomMembersResponses(
+    boolean isFull,
+    List<RoomMembersResponse> members
+) {
+
+    public static RoomMembersResponses of(Room room, List<Member> members) {
+        return new RoomMembersResponses(room.isFull(members.size()), getMemberResponses(members));
+    }
+
+    private static List<RoomMembersResponse> getMemberResponses(List<Member> members) {
+        return members.stream()
+            .map(member -> new RoomMembersResponse(
+                member.getMemberId(),
+                member.getProfile(),
+                member.getNickname(),
+                member.getRole()
+            )).toList();
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/web/RoomController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/in/web/RoomController.java
@@ -7,7 +7,7 @@ import com.kok.kokapi.room.adapter.in.dto.request.JoinRoomParticipantRequest;
 import com.kok.kokapi.room.adapter.in.dto.response.JoinRoomResponse;
 import com.kok.kokapi.room.adapter.in.dto.response.RoomCreateResponse;
 import com.kok.kokapi.room.adapter.in.dto.response.RoomDetailResponse;
-import com.kok.kokapi.room.adapter.in.dto.response.RoomMembersResponse;
+import com.kok.kokapi.room.adapter.in.dto.response.RoomMembersResponses;
 import com.kok.kokapi.room.adapter.in.dto.response.RoomStatusResponse;
 import com.kok.kokapi.room.application.service.RoomFacadeService;
 import com.kok.kokcore.room.domain.Member;
@@ -75,20 +75,13 @@ public class RoomController {
 
     @Operation(summary = "약속방 참여자 프로필 목록 조회", description = "약속방에 참여 중인 참여자들의 프로필 목록을 반환합니다.")
     @GetMapping("/rooms/{roomId}/participants")
-    public ResponseEntity<ApiResponseDto<List<RoomMembersResponse>>> getParticipants(
+    public ResponseEntity<ApiResponseDto<RoomMembersResponses>> getParticipants(
         @PathVariable String roomId) {
         Room room = getRoomUseCase.findRoomById(roomId);
         List<Member> participants = getRoomUseCase.getParticipants(room.getId());
+        RoomMembersResponses responses = RoomMembersResponses.of(room, participants);
 
-        List<RoomMembersResponse> response = participants.stream()
-            .map(member -> new RoomMembersResponse(
-                member.getMemberId(),
-                member.getProfile(),
-                member.getNickname(),
-                member.getRole()
-            )).toList();
-
-        return ResponseEntity.ok(ApiResponseDto.success(response));
+        return ResponseEntity.ok(ApiResponseDto.success(responses));
     }
 
     @Operation(summary = "약속방 참여", description = "사용자가 약속방에 참여합니다.")

--- a/kok-api/src/test/java/com/kok/kokapi/room/adapter/in/web/RoomIntegrationTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/room/adapter/in/web/RoomIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.kok.kokapi.room.adapter.in.web;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import com.kok.kokapi.centroid.adapter.in.dto.request.LocationRequest;
@@ -32,14 +33,15 @@ class RoomIntegrationTest extends IntegrationTest {
 
             inputLocation("방장이 출발지 정보를 입력한다.", createRoomResponse),
 
-            getRoomDetail("약속방 정보를 조회해보면 미참여자는 1명이고, isFulled는 false이다.", createRoomResponse, 1,
-                false),
+            getRoomDetail("약속방 정보를 조회해보면 미참여자는 1명이다", createRoomResponse, 1),
 
             DynamicTest.dynamicTest("팔로워가 약속방에 참여한다.",
                 () -> joinRoomResponse.set(joinRoom(createRoomResponse.get().id(),
                     new JoinRoomParticipantRequest("profile", "follower")))),
 
-            getRoomDetail("약속방 정보를 조회해보면 미참여자는 0명이고, isFulled는 true이다.", createRoomResponse, 0,
+            getRoomDetail("약속방 정보를 조회해보면 미참여자는 0명이다.", createRoomResponse, 0),
+
+            getRoomMembers("약속방 프로필 목록을 조회하면 isFulㅣ은 true이고, 2명의 프로필이 있다", createRoomResponse, 2,
                 true),
 
             checkVoteMode("아직 출발지 입력을 완료하지 않았기에 voteMode는 false이다.", createRoomResponse, false),
@@ -89,8 +91,7 @@ class RoomIntegrationTest extends IntegrationTest {
     }
 
     private static DynamicTest getRoomDetail(String message,
-        AtomicReference<RoomCreateResponse> createRoomResponse, int nonParticipantCount,
-        boolean expectedIsFulled) {
+        AtomicReference<RoomCreateResponse> createRoomResponse, int nonParticipantCount) {
         return DynamicTest.dynamicTest(message,
             () -> {
                 String roomId = createRoomResponse.get().id();
@@ -99,8 +100,23 @@ class RoomIntegrationTest extends IntegrationTest {
                     .when().get("/v1/api/rooms/" + roomId)
                     .then().log().all()
                     .assertThat().statusCode(200)
-                    .body("data.nonParticipantCount", is(nonParticipantCount))
-                    .body("data.isFulled", is(expectedIsFulled));
+                    .body("data.nonParticipantCount", is(nonParticipantCount));
+            });
+    }
+
+    private static DynamicTest getRoomMembers(String message,
+        AtomicReference<RoomCreateResponse> createRoomResponse, int profileCount,
+        boolean expectedIsFull) {
+        return DynamicTest.dynamicTest(message,
+            () -> {
+                String roomId = createRoomResponse.get().id();
+                RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .when().get("/v1/api/rooms/" + roomId + "/participants")
+                    .then().log().all()
+                    .assertThat().statusCode(200)
+                    .body("data.members", hasSize(profileCount))
+                    .body("data.isFull", is(expectedIsFull));
             });
     }
 

--- a/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
@@ -56,4 +56,8 @@ public class Room implements Serializable {
     private boolean isAllLocationInput(long participantCount) {
         return participantCount == capacity;
     }
+
+    public boolean isFull(int participantCount) {
+        return capacity == participantCount;
+    }
 }


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
- #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 약속방 조회에 추가했던 `isFulled` 필드를 프로필 목록 조회 API로 이동했습니다.
- `isFull` 필드는 방의 참여자가 모두 참여했는지를 나타내는 플래그입니다.
- `isFulled` -> `isFull` : full은 형용사이기 때문에 이와 같이 수정했습니다! 

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
