### PR TITLE
:sparkles: [Feature/location] add member profile image field to LocationResponse

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/dto/response/LocationResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/dto/response/LocationResponse.java
@@ -6,13 +6,21 @@ import java.math.RoundingMode;
 public record LocationResponse(
     String roomId,
     String memberId,
+    String imageUrl,
     BigDecimal latitude,
     BigDecimal longitude
 ) {
 
     public static LocationResponse of(String roomId, String memberId, BigDecimal latitude,
         BigDecimal longitude) {
-        return new LocationResponse(roomId, memberId,
+        return new LocationResponse(roomId, memberId, "",
+            latitude.setScale(6, RoundingMode.HALF_UP),
+            longitude.setScale(6, RoundingMode.HALF_UP));
+    }
+
+    public static LocationResponse of(String roomId, String memberId, String imageUrl, BigDecimal latitude,
+        BigDecimal longitude) {
+        return new LocationResponse(roomId, memberId, imageUrl,
             latitude.setScale(6, RoundingMode.HALF_UP),
             longitude.setScale(6, RoundingMode.HALF_UP));
     }

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/dto/response/LocationResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/dto/response/LocationResponse.java
@@ -6,6 +6,7 @@ import java.math.RoundingMode;
 public record LocationResponse(
     String roomId,
     String memberId,
+    String imageUrl,
     BigDecimal latitude,
     BigDecimal longitude,
     String name
@@ -13,7 +14,15 @@ public record LocationResponse(
 
     public static LocationResponse of(String roomId, String memberId, BigDecimal latitude,
         BigDecimal longitude, String name) {
-        return new LocationResponse(roomId, memberId,
+        return new LocationResponse(roomId, memberId, "",
+            latitude.setScale(6, RoundingMode.HALF_UP),
+            longitude.setScale(6, RoundingMode.HALF_UP),
+            name);
+    }
+
+    public static LocationResponse of(String roomId, String memberId, String imageUrl, BigDecimal latitude,
+        BigDecimal longitude, String name) {
+        return new LocationResponse(roomId, memberId, imageUrl,
             latitude.setScale(6, RoundingMode.HALF_UP),
             longitude.setScale(6, RoundingMode.HALF_UP),
             name);

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/web/LocationController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/web/LocationController.java
@@ -11,6 +11,8 @@ import com.kok.kokcore.location.domain.Location;
 import com.kok.kokcore.location.usecase.CreateLocationUseCase;
 import com.kok.kokcore.location.usecase.LoadCentroidUseCase;
 import com.kok.kokcore.location.usecase.ReadLocationUseCase;
+import com.kok.kokcore.room.domain.Member;
+import com.kok.kokcore.room.usecase.GetRoomUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -31,6 +33,7 @@ public class LocationController {
     private final CreateLocationUseCase createLocationUsecase;
     private final LoadCentroidUseCase loadCentroidUsecase;
     private final ReadLocationUseCase readLocationUsecase;
+    private final GetRoomUseCase getRoomUseCase;
     private final LocationMapper locationMapper;
 
     @Operation(summary = "위치 입력", description = "Create a new location with the provided details.")
@@ -69,8 +72,11 @@ public class LocationController {
     public ResponseEntity<ApiResponseDto<LocationResponse>> getLocation(@PathVariable String roomId,
         @PathVariable String memberId) {
         Location location = readLocationUsecase.readLocation(roomId, memberId);
+        Member member = getRoomUseCase.getParticipant(roomId, memberId);
 
-        return ResponseEntity.ok(ApiResponseDto.success(locationMapper.toResponse(location)));
+        return ResponseEntity.ok(ApiResponseDto.success(
+            locationMapper.toResponse(location, member)
+        ));
     }
 
     @Operation(summary = "위치조회 ConvexHull", description = "Retrieve the ConvexHull inside list, outside list of locations for a roomId")

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/web/LocationController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/in/web/LocationController.java
@@ -11,6 +11,8 @@ import com.kok.kokcore.location.domain.Location;
 import com.kok.kokcore.location.usecase.CreateLocationUseCase;
 import com.kok.kokcore.location.usecase.LoadCentroidUseCase;
 import com.kok.kokcore.location.usecase.ReadLocationUseCase;
+import com.kok.kokcore.room.domain.Member;
+import com.kok.kokcore.room.usecase.GetRoomUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -31,6 +33,7 @@ public class LocationController {
     private final CreateLocationUseCase createLocationUsecase;
     private final LoadCentroidUseCase loadCentroidUsecase;
     private final ReadLocationUseCase readLocationUsecase;
+    private final GetRoomUseCase getRoomUseCase;
     private final LocationMapper locationMapper;
 
     @Operation(summary = "위치 입력", description = "Create a new location with the provided details.")
@@ -70,8 +73,11 @@ public class LocationController {
     public ResponseEntity<ApiResponseDto<LocationResponse>> getLocation(@PathVariable String roomId,
         @PathVariable String memberId) {
         Location location = readLocationUsecase.readLocation(roomId, memberId);
+        Member member = getRoomUseCase.getParticipant(roomId, memberId);
 
-        return ResponseEntity.ok(ApiResponseDto.success(locationMapper.toResponse(location)));
+        return ResponseEntity.ok(ApiResponseDto.success(
+            locationMapper.toResponse(location, member)
+        ));
     }
 
     @Operation(summary = "위치조회 ConvexHull", description = "Retrieve the ConvexHull inside list, outside list of locations for a roomId")

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
@@ -3,6 +3,7 @@ package com.kok.kokapi.centroid.adapter.out.mapper;
 import com.kok.kokapi.centroid.adapter.in.dto.response.LocationResponse;
 import com.kok.kokapi.config.geometry.PointConverter;
 import com.kok.kokcore.location.domain.Location;
+import com.kok.kokcore.room.domain.Member;
 import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.data.util.Pair;
@@ -23,6 +24,18 @@ public class LocationMapper {
         return LocationResponse.of(
             location.getRoomId(),
             location.getMemberId(),
+            coordinates.getFirst(),
+            coordinates.getSecond()
+        );
+    }
+
+    public LocationResponse toResponse(Location location, Member member) {
+        Pair<BigDecimal, BigDecimal> coordinates = pointConverter.toCoordinates(
+            location.getLocation_point());
+        return LocationResponse.of(
+            location.getRoomId(),
+            member.getMemberId(),
+            member.getProfile(),
             coordinates.getFirst(),
             coordinates.getSecond()
         );

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
@@ -38,19 +38,8 @@ public class LocationMapper {
             member.getMemberId(),
             member.getProfile(),
             coordinates.getFirst(),
-            coordinates.getSecond()
-        );
-    }
-
-    public LocationResponse toResponse(Location location, Member member) {
-        Pair<BigDecimal, BigDecimal> coordinates = pointConverter.toCoordinates(
-            location.getLocation_point());
-        return LocationResponse.of(
-            location.getRoomId(),
-            member.getMemberId(),
-            member.getProfile(),
-            coordinates.getFirst(),
-            coordinates.getSecond()
+            coordinates.getSecond(),
+            location.getName()
         );
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
+++ b/kok-api/src/main/java/com/kok/kokapi/centroid/adapter/out/mapper/LocationMapper.java
@@ -3,6 +3,7 @@ package com.kok.kokapi.centroid.adapter.out.mapper;
 import com.kok.kokapi.centroid.adapter.in.dto.response.LocationResponse;
 import com.kok.kokapi.config.geometry.PointConverter;
 import com.kok.kokcore.location.domain.Location;
+import com.kok.kokcore.room.domain.Member;
 import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.data.util.Pair;
@@ -26,6 +27,18 @@ public class LocationMapper {
             coordinates.getFirst(),
             coordinates.getSecond(),
             location.getName()
+        );
+    }
+
+    public LocationResponse toResponse(Location location, Member member) {
+        Pair<BigDecimal, BigDecimal> coordinates = pointConverter.toCoordinates(
+            location.getLocation_point());
+        return LocationResponse.of(
+            location.getRoomId(),
+            member.getMemberId(),
+            member.getProfile(),
+            coordinates.getFirst(),
+            coordinates.getSecond()
         );
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/room/application/service/RoomQueryService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/application/service/RoomQueryService.java
@@ -48,6 +48,14 @@ public class RoomQueryService implements GetRoomUseCase {
     }
 
     @Override
+    public Member getParticipant(String roomId, String memberId) {
+        return getParticipants(roomId).stream()
+            .filter(member -> member.getMemberId().equals(memberId))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Member not found with id: " + memberId));
+    }
+
+    @Override
     public int getParticipantsCount(String roomId) {
         Long participantCount = loadRoomParticipantPort.countParticipantsById(roomId);
         return participantCount.intValue();

--- a/kok-core/src/main/java/com/kok/kokcore/room/usecase/GetRoomUseCase.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/usecase/GetRoomUseCase.java
@@ -10,5 +10,7 @@ public interface GetRoomUseCase {
 
     List<Member> getParticipants(String roomId);
 
+    Member getParticipant(String roomId, String memberId);
+
     int getParticipantsCount(String roomId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #82 

## 📝 작업 내용
> 이번 PR에서는 지도 상에 Profile Image를 마커로 표시하기 위해서 LocationResponse에 Image Url 필드를 추가하였습니다.

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
