### PR TITLE
:sparkles: [Feature/places] implements google search place API

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/request/PlacesRequest.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/request/PlacesRequest.java
@@ -1,0 +1,31 @@
+package com.kok.kokapi.place.adapter.in.dto.request;
+
+import com.kok.kokcore.places.port.in.PlaceInput;
+import com.kok.kokcore.places.domain.model.vo.PlaceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+
+public record PlacesRequest(
+    @NotBlank(message = "장소 카테고리는 필수값입니다.")
+    PlaceType placeType,
+
+    @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다.")
+    @DecimalMax(value = "43.0", message = "위도는 43 이하이어야 합니다.")
+    @Schema(defaultValue = "37.5665", description = "위도")
+    double latitude,
+
+    @DecimalMin(value = "123.0", message = "경도는 123 이상이어야 합니다.")
+    @DecimalMax(value = "132.0", message = "경도는 132 이하이어야 합니다.")
+    @Schema(defaultValue = "126.9788", description = "경도")
+    double longitude,
+
+    @Schema(defaultValue = "20", description = "최대 개수 20")
+    Integer maxCount
+) {
+    public PlaceInput toPlaceInput() {
+        return new PlaceInput(placeType, latitude, longitude, maxCount);
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/response/PlaceResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/response/PlaceResponse.java
@@ -1,0 +1,31 @@
+package com.kok.kokapi.place.adapter.in.dto.response;
+
+import com.kok.kokcore.places.domain.model.Place;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class PlaceResponse {
+    private final String displayName;
+    private final String formattedAddress;
+    private final Location location;
+
+    public PlaceResponse(Place place) {
+        this.displayName = place.getName();
+        this.formattedAddress = place.getAddress();
+        this.location = new Location(place.getLatitude(), place.getLongitude());
+    }
+
+    @Getter
+    @ToString
+    public static class Location {
+        private final double latitude;
+        private final double longitude;
+
+        public Location(double latitude, double longitude) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+        }
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/response/PlacesResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/dto/response/PlacesResponse.java
@@ -1,0 +1,23 @@
+package com.kok.kokapi.place.adapter.in.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+import java.util.stream.Collectors;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
+public class PlacesResponse {
+    private final List<PlaceResponse> placeResponses;
+
+    public PlacesResponse(PlacesResult placesResult) {
+        this.placeResponses = placesResult.places()
+            .stream()
+            .map(PlaceResponse::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/web/PlacesController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/adapter/in/web/PlacesController.java
@@ -1,0 +1,28 @@
+package com.kok.kokapi.place.adapter.in.web;
+
+import com.kok.kokapi.common.response.ApiResponseDto;
+import com.kok.kokapi.config.annotion.V1Controller;
+import com.kok.kokapi.place.adapter.in.dto.request.PlacesRequest;
+import com.kok.kokapi.place.adapter.in.dto.response.PlacesResponse;
+import com.kok.kokcore.places.usecase.SearchPlaceUseCase;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@V1Controller
+@RequiredArgsConstructor
+public class PlacesController {
+
+    private final SearchPlaceUseCase searchPlaceUseCase;
+
+    @Operation(summary = "주변 플레이스 조회", description = "추천 장소 주변의 핫플레이스 목록을 조회합니다.")
+    @PostMapping("/search/places")
+    public ResponseEntity<ApiResponseDto<PlacesResponse>> searchPlaces(@RequestBody PlacesRequest request) throws Exception {
+        PlacesResult result = searchPlaceUseCase.getPlaces(request.toPlaceInput());
+        PlacesResponse response = new PlacesResponse(result);
+        return ResponseEntity.ok(ApiResponseDto.success(response));
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/place/adapter/out/external/GooglePlaceApiAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/adapter/out/external/GooglePlaceApiAdapter.java
@@ -1,0 +1,109 @@
+package com.kok.kokapi.place.adapter.out.external;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kok.kokcore.places.port.in.PlaceInput;
+import com.kok.kokcore.places.port.out.LoadPlacesPort;
+import com.kok.kokcore.places.domain.model.Place;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+import com.kok.kokcore.places.domain.model.vo.PlaceType;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GooglePlaceApiAdapter implements LoadPlacesPort {
+
+    @Value("${google.places.api.key}")
+    private String apiKey;
+
+    private static final String GOOGLE_PLACE_BASE_URL = "https://places.googleapis.com/v1/places:searchNearby";
+    private static final double DEFAULT_RADIUS = 5000.0;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public PlacesResult getPlaces(PlaceInput input) {
+        String jsonBody = buildRequestBody(input);
+        RestClient restClient = RestClient.create();
+
+        try {
+            String responseBody = restClient.method(HttpMethod.POST)
+                .uri(GOOGLE_PLACE_BASE_URL)
+                .header("Content-Type", "application/json")
+                .header("X-Goog-Api-Key", apiKey)
+                .header("X-Goog-FieldMask",
+                    "places.displayName,places.formattedAddress,places.location").body(jsonBody)
+                .retrieve()
+                .body(String.class);
+
+            return mapToPlacesResult(responseBody, input.placeType());
+        } catch (IOException e) {
+            log.error("Error while calling Google Places API", e);
+            throw new RuntimeException("Call Google Places API Failed", e);
+        }
+    }
+
+    private static String buildRequestBody(PlaceInput input) {
+        String includedTypes = input.placeType().getPlaceCategories().stream()
+            .map(category -> "\"" + category + "\"")
+            .collect(Collectors.joining(", "));
+
+        return String.format("""
+                {
+                    "includedTypes": [%s],
+                    "maxResultCount": %d,
+                    "locationRestriction": {
+                        "circle": {
+                            "center": {
+                                "latitude": %.6f,
+                                "longitude": %.6f
+                            },
+                            "radius": %.1f
+                        }
+                    },
+                    "languageCode": "ko"
+                }
+                """,
+            includedTypes,
+            input.maxCount(),
+            input.latitude(),
+            input.longitude(),
+            DEFAULT_RADIUS);
+    }
+
+    private PlacesResult mapToPlacesResult(String responseBody, PlaceType placeType) throws JsonProcessingException {
+        JsonNode root = objectMapper.readTree(responseBody);
+        JsonNode placesNode = root.get("places");
+        List<Place> places = new ArrayList<>();
+
+        for (JsonNode node : placesNode) {
+            String name = node.path("displayName").path("text").asText();
+            String address = node.path("formattedAddress").asText();
+            double latitude = node.path("location").path("latitude").asDouble();
+            double longitude = node.path("location").path("longitude").asDouble();
+
+            Place place = Place.builder()
+                .name(name)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .placeType(placeType)
+                .build();
+
+            places.add(place);
+        }
+        return new PlacesResult(places);
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/place/application/service/PlacesService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/place/application/service/PlacesService.java
@@ -1,0 +1,20 @@
+package com.kok.kokapi.place.application.service;
+
+import com.kok.kokcore.places.port.in.PlaceInput;
+import com.kok.kokcore.places.port.out.LoadPlacesPort;
+import com.kok.kokcore.places.usecase.SearchPlaceUseCase;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlacesService implements SearchPlaceUseCase {
+
+    private final LoadPlacesPort loadPlacesPort;
+
+    @Override
+    public PlacesResult getPlaces(PlaceInput input) {
+        return loadPlacesPort.getPlaces(input);
+    }
+}

--- a/kok-api/src/main/resources/application-dev.yml
+++ b/kok-api/src/main/resources/application-dev.yml
@@ -41,7 +41,10 @@ station:
 
 ncp:
   object-storage-url: ${OBJECT_STORAGE_URL}
-
+google:
+  places:
+    api:
+      key: ${GOOGLE_PLACE_API_KEY}
 tmap-sub:
   key: ${TMAP_KEY}
   url: "https://apis.openapi.sk.com/transit/routes/sub"

--- a/kok-api/src/main/resources/application-prod.yml
+++ b/kok-api/src/main/resources/application-prod.yml
@@ -51,7 +51,10 @@ station:
 
 ncp:
   object-storage-url: ${OBJECT_STORAGE_URL}
-
+google:
+  places:
+    api:
+      key: ${GOOGLE_API_KEY}
 tmap-sub:
   key: ${TMAP_KEY}
   url: "https://apis.openapi.sk.com/transit/routes/sub"

--- a/kok-core/src/main/java/com/kok/kokcore/places/domain/model/Place.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/domain/model/Place.java
@@ -1,0 +1,17 @@
+package com.kok.kokcore.places.domain.model;
+
+import com.kok.kokcore.places.domain.model.vo.PlaceType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class Place {
+    private final String name;
+    private final String address;
+    private final double latitude;
+    private final double longitude;
+    private final PlaceType placeType;
+}

--- a/kok-core/src/main/java/com/kok/kokcore/places/domain/model/PlacesResult.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/domain/model/PlacesResult.java
@@ -1,0 +1,7 @@
+package com.kok.kokcore.places.domain.model;
+
+import java.util.List;
+
+public record PlacesResult(
+    List<Place> places
+) { }

--- a/kok-core/src/main/java/com/kok/kokcore/places/domain/model/vo/PlaceType.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/domain/model/vo/PlaceType.java
@@ -1,0 +1,42 @@
+package com.kok.kokcore.places.domain.model.vo;
+
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * Place 유형 Enum
+ */
+@Getter
+public enum PlaceType {
+    ACTIVITY(List.of(
+        "amusement_park", "aquarium", "art_gallery", "bowling_alley", "gym", "movie_theater",
+        "museum", "night_club", "spa", "stadium", "tourist_attraction", "zoo"
+    )),
+    RESTAURANT(List.of(
+        "restaurant", "meal_delivery", "meal_takeaway"
+    )),
+    CAFE(List.of(
+        "cafe", "bakery"
+    )),
+    BAR(List.of("bar")),
+    PARK(List.of(
+        "park", "campground", "rv_park"
+    )),
+    CULTURE(List.of(
+        "library", "church", "hindu_temple", "mosque", "synagogue"
+    )),
+    EVENT(List.of(
+        "casino", "movie_theater", "stadium"
+    )),
+    SHOPPING(List.of(
+        "shopping_mall", "clothing_store", "convenience_store", "department_store",
+        "electronics_store", "furniture_store", "hardware_store", "home_goods_store",
+        "jewelry_store", "liquor_store", "shoe_store", "store", "supermarket"
+    ));
+
+    private final List<String> placeCategories;
+
+    PlaceType(List<String> placeCategories) {
+        this.placeCategories = placeCategories;
+    }
+}

--- a/kok-core/src/main/java/com/kok/kokcore/places/port/in/PlaceInput.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/port/in/PlaceInput.java
@@ -1,0 +1,14 @@
+package com.kok.kokcore.places.port.in;
+
+import com.kok.kokcore.places.domain.model.vo.PlaceType;
+
+public record PlaceInput(
+    PlaceType placeType,
+    double latitude,
+    double longitude,
+    Integer maxCount
+) {
+    public PlaceInput {
+        maxCount = (maxCount == null) ? 20 : maxCount;
+    }
+}

--- a/kok-core/src/main/java/com/kok/kokcore/places/port/out/LoadPlacesPort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/port/out/LoadPlacesPort.java
@@ -1,0 +1,9 @@
+package com.kok.kokcore.places.port.out;
+
+
+import com.kok.kokcore.places.port.in.PlaceInput;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+
+public interface LoadPlacesPort {
+    PlacesResult getPlaces(PlaceInput input);
+}

--- a/kok-core/src/main/java/com/kok/kokcore/places/usecase/SearchPlaceUseCase.java
+++ b/kok-core/src/main/java/com/kok/kokcore/places/usecase/SearchPlaceUseCase.java
@@ -1,0 +1,12 @@
+package com.kok.kokcore.places.usecase;
+
+import com.kok.kokcore.places.port.in.PlaceInput;
+import com.kok.kokcore.places.domain.model.PlacesResult;
+
+/**
+ * 주변 장소 검색 유스케이스
+ * PlaceInput을 받아 검색 결과(PlacesResult)를 반환합니다.
+ */
+public interface SearchPlaceUseCase {
+    PlacesResult getPlaces(PlaceInput input) throws Exception;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #9, #11 

## 📝 작업 내용
1. 투표 후보지에서 둘러보기 버튼을 눌렀을때 주변 탐색 기능을 구현하였습니다. (아래 스크린샷 참조)
2. Google Places API를 사용하여 주변의 음식점, 카페, 백화점, 쇼핑몰 등의 장소 정보를 가져오는 기능을 구현하였습니다.


### ***📸 스크린샷 (선택)***

<img width="261" alt="주변탐색1" src="https://github.com/user-attachments/assets/48802e72-7bd3-412c-b261-886deb9a2e3d" />

<img width="253" alt="주변탐색2" src="https://github.com/user-attachments/assets/b764e631-752d-4324-b9a8-05f387790e4a" />

## ***💬 리뷰 요구사항(선택)***
1. 초기에는 네이버 Map 맛집 검색 정보에 대한 웹 크롤링 방안을 검토하였으나 정적 페이지가 아닌 동적 페이지여서 크롤링 과정에서 셀레니움을 사용해야했습니다. 또한 테스트 과정에서 잦은 크롤링 시도 시 네이버 지도측에서 크롤링이 언제든지 차단될 수 있기에 구글 Places API를 사용하기로 하였습니다.

2. 디자이너, 프론트 담당자와 논의한 결과 가게명, 가게위치(위도, 경도), 주소 정보만 필요한 점과 트래픽을 고려했을때 API 호출 비용이 크지 않은 점을 고려하여 API 사용으로 결정하였습니다.