### PR TITLE
✨ [Feature/vote] implement getting vote final result API

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/station/adapter/in/web/StationController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/station/adapter/in/web/StationController.java
@@ -25,6 +25,12 @@ public class StationController {
     private final RetrieveRouteUseCase retrieveRouteUseCase;
     private final StationFacadeService stationFacadeService;
 
+    /**
+     * 1차 MVP 기준 최종 결과 조회 API
+     *
+     * @param keyword
+     * @return
+     */
     @Operation(summary = "추천 지하철역 리턴", description = "Recommend subway stations based on the user's location.")
     @GetMapping("/stations/recommend/{roomId}")
     public ResponseEntity<ApiResponseDto<List<RecommendedStationResponse>>> recommendStations(

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/CandidateResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/CandidateResponse.java
@@ -12,10 +12,11 @@ public record CandidateResponse(
     List<String> routes,
     Integer totalTime,
     Integer transferCount,
+    boolean isKokRecommended,
     List<CommentResponse> comments
 ) {
 
-    public static CandidateResponse of(
+    public static CandidateResponse recommended(
         Station station,
         List<Route> routes,
         TmapPublicTransportationParsedResponse transportationParsedResponse,
@@ -29,6 +30,26 @@ public record CandidateResponse(
                 transportationParsedResponse.totalTime() : null,
             Objects.nonNull(transportationParsedResponse) ?
                 transportationParsedResponse.transferCount() : null,
+            true,
+            comments
+        );
+    }
+
+    public static CandidateResponse custom(
+        Station station,
+        List<Route> routes,
+        TmapPublicTransportationParsedResponse transportationParsedResponse,
+        List<CommentResponse> comments //comment 도메인 구현 시 List<Comment>로 교체
+    ) {
+        return new CandidateResponse(
+            station.getId(),
+            station.getName(),
+            getRoutes(routes),
+            Objects.nonNull(transportationParsedResponse) ?
+                transportationParsedResponse.totalTime() : null,
+            Objects.nonNull(transportationParsedResponse) ?
+                transportationParsedResponse.transferCount() : null,
+            false,
             comments
         );
     }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/CandidateResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/CandidateResponse.java
@@ -4,13 +4,14 @@ import com.kok.kokapi.public_transportation.adapter.in.dto.response.TmapPublicTr
 import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import java.util.List;
+import java.util.Objects;
 
 public record CandidateResponse(
     long stationId,
     String stationName,
     List<String> routes,
-    int totalTime,
-    int transferCount,
+    Integer totalTime,
+    Integer transferCount,
     List<CommentResponse> comments
 ) {
 
@@ -24,8 +25,10 @@ public record CandidateResponse(
             station.getId(),
             station.getName(),
             getRoutes(routes),
-            transportationParsedResponse.totalTime(),
-            transportationParsedResponse.transferCount(),
+            Objects.nonNull(transportationParsedResponse) ?
+                transportationParsedResponse.totalTime() : null,
+            Objects.nonNull(transportationParsedResponse) ?
+                transportationParsedResponse.transferCount() : null,
             comments
         );
     }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/MemberVoteStatusResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/MemberVoteStatusResponse.java
@@ -1,19 +1,22 @@
 package com.kok.kokapi.vote.adapter.in.dto.response;
 
+import com.kok.kokcore.location.domain.Location;
 import com.kok.kokcore.room.domain.Member;
 
 public record MemberVoteStatusResponse(
     String memberId,
     String nickname,
     String imageUrl,
+    String address,
     boolean isVoted
 ) {
 
-    public static MemberVoteStatusResponse of(Member member, boolean isVoted) {
+    public static MemberVoteStatusResponse of(Member member, Location location, boolean isVoted) {
         return new MemberVoteStatusResponse(
             member.getMemberId(),
             member.getNickname(),
             member.getProfile(),
+            location.getName(),
             isVoted
         );
     }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/VoteResultStationResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/VoteResultStationResponse.java
@@ -1,0 +1,27 @@
+package com.kok.kokapi.vote.adapter.in.dto.response;
+
+import com.kok.kokcore.station.domain.entity.Route;
+import com.kok.kokcore.station.domain.entity.Station;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record VoteResultStationResponse(
+    long id,
+    String name,
+    BigDecimal latitude,
+    BigDecimal longitude,
+    long priority,
+    List<String> routes
+) {
+
+    public static VoteResultStationResponse of(Station station, List<Route> routes) {
+        return new VoteResultStationResponse(
+            station.getId(),
+            station.getName(),
+            station.getLatitude(),
+            station.getLongitude(),
+            station.getPriority(),
+            routes.stream().map(Route::getName).toList()
+        );
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
@@ -16,9 +16,9 @@ import com.kok.kokcore.room.usecase.UpdateRoomUseCase;
 import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import com.kok.kokcore.station.usecase.RetrieveRouteUseCase;
-import com.kok.kokcore.vote.usecase.GetCandidateUseCase;
+import com.kok.kokcore.station.usecase.SystemRecommendUseCase;
+import com.kok.kokcore.station.usecase.UserRecommendUseCase;
 import com.kok.kokcore.vote.usecase.GetVoteUseCase;
-import com.kok.kokcore.vote.usecase.SaveVoteUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,17 +38,18 @@ public class VoteController {
     private final GetRoomUseCase getRoomUseCase;
     private final GetVoteUseCase getVoteUseCase;
     private final RetrieveRouteUseCase retrieveRouteUseCase;
-    private final SaveVoteUseCase saveVoteUseCase;
     private final UpdateRoomUseCase updateRoomUseCase;
-    private final GetCandidateUseCase getCandidateUseCase;
+    private final SystemRecommendUseCase systemRecommendedUseCase;
+    private final UserRecommendUseCase userRecommendUseCase;
 
     @Operation(summary = "투표 후보지 목록 조회", description = "방 ID과 사용자 ID를 기반으로 투표 후보지 상세 정보를 조회합니다.")
     @GetMapping("/votes/{roomId}/{memberId}/candidates")
     public ResponseEntity<ApiResponseDto<List<CandidateResponse>>> getCandidates(
         @PathVariable String roomId, @PathVariable String memberId) {
-        List<Station> stations = stationFacadeService.getCandidateStation(roomId);
+        List<Station> recommendedStations = systemRecommendedUseCase.systemRecommendStation(roomId);
+        List<Station> customStations = userRecommendUseCase.getUserRecommendStation(roomId);
         List<CandidateResponse> responses = voteFacadeService.getCandidates(
-            roomId, memberId, stations);
+            roomId, memberId, recommendedStations, customStations);
         return ResponseEntity.ok(ApiResponseDto.success(responses));
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
@@ -7,10 +7,14 @@ import com.kok.kokapi.vote.adapter.in.dto.request.VoteRequest;
 import com.kok.kokapi.vote.adapter.in.dto.response.CandidateResponse;
 import com.kok.kokapi.vote.adapter.in.dto.response.MemberVoteStatusResponse;
 import com.kok.kokapi.vote.adapter.in.dto.response.VoteDeadlineResponse;
+import com.kok.kokapi.vote.adapter.in.dto.response.VoteResultStationResponse;
 import com.kok.kokapi.vote.application.service.VoteFacadeService;
 import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.room.usecase.GetRoomUseCase;
+import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
+import com.kok.kokcore.station.usecase.RetrieveRouteUseCase;
+import com.kok.kokcore.vote.usecase.GetVoteUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,6 +32,8 @@ public class VoteController {
     private final VoteFacadeService voteFacadeService;
     private final StationFacadeService stationFacadeService;
     private final GetRoomUseCase getRoomUseCase;
+    private final GetVoteUseCase getVoteUseCase;
+    private final RetrieveRouteUseCase retrieveRouteUseCase;
 
     @Operation(summary = "투표 후보지 목록 조회", description = "방 ID과 사용자 ID를 기반으로 투표 후보지 상세 정보를 조회합니다.")
     @GetMapping("/votes/{roomId}/{memberId}/candidates")
@@ -64,6 +70,16 @@ public class VoteController {
         @PathVariable String roomId) {
         Room room = getRoomUseCase.findRoomById(roomId, LocalDateTime.now());
         VoteDeadlineResponse response = VoteDeadlineResponse.from(room);
+        return ResponseEntity.ok(ApiResponseDto.success(response));
+    }
+
+    @Operation(summary = "투표 최종 결과 조회", description = "방 ID에 대한 최종 투표 결과를 조회합니다.")
+    @GetMapping("/votes/{roomId}/results")
+    public ResponseEntity<ApiResponseDto<VoteResultStationResponse>> getFinalResult(
+        @PathVariable String roomId) {
+        Station station = getVoteUseCase.getVoteFinalResult(roomId);
+        List<Route> routes = retrieveRouteUseCase.retrieveRoutes(station);
+        VoteResultStationResponse response = VoteResultStationResponse.of(station, routes);
         return ResponseEntity.ok(ApiResponseDto.success(response));
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
@@ -69,7 +69,7 @@ public class VoteController {
         return ResponseEntity.ok(ApiResponseDto.success(responses));
     }
 
-    @Operation(summary = "투표 마감 시간 조회", description = "방 ID에 대한 투표 마감 시간을 조회합니다.")
+    @Operation(summary = "투표 마감 시간 조회", description = "방 ID에 대한 투표 마감 시간(UTC)을 조회합니다.")
     @GetMapping("/votes/{roomId}/deadline")
     public ResponseEntity<ApiResponseDto<VoteDeadlineResponse>> getVoteDeadline(
         @PathVariable String roomId) {

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
@@ -16,6 +16,7 @@ import com.kok.kokcore.room.usecase.UpdateRoomUseCase;
 import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import com.kok.kokcore.station.usecase.RetrieveRouteUseCase;
+import com.kok.kokcore.vote.usecase.GetCandidateUseCase;
 import com.kok.kokcore.vote.usecase.GetVoteUseCase;
 import com.kok.kokcore.vote.usecase.SaveVoteUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,14 +40,15 @@ public class VoteController {
     private final RetrieveRouteUseCase retrieveRouteUseCase;
     private final SaveVoteUseCase saveVoteUseCase;
     private final UpdateRoomUseCase updateRoomUseCase;
+    private final GetCandidateUseCase getCandidateUseCase;
 
     @Operation(summary = "투표 후보지 목록 조회", description = "방 ID과 사용자 ID를 기반으로 투표 후보지 상세 정보를 조회합니다.")
     @GetMapping("/votes/{roomId}/{memberId}/candidates")
     public ResponseEntity<ApiResponseDto<List<CandidateResponse>>> getCandidates(
         @PathVariable String roomId, @PathVariable String memberId) {
         List<Station> stations = stationFacadeService.getCandidateStation(roomId);
-        List<CandidateResponse> responses = voteFacadeService.getCandidates(roomId, memberId,
-            stations);
+        List<CandidateResponse> responses = voteFacadeService.getCandidates(
+            roomId, memberId, stations);
         return ResponseEntity.ok(ApiResponseDto.success(responses));
     }
 
@@ -57,7 +59,8 @@ public class VoteController {
         @PathVariable String memberId,
         @RequestBody VoteRequest voteRequest
     ) {
-        saveVoteUseCase.saveVotes(roomId, memberId, voteRequest.agreedStationIds());
+        List<Station> stations = stationFacadeService.getCandidateStation(roomId);
+        voteFacadeService.saveVotes(roomId, memberId, voteRequest.agreedStationIds(), stations);
         return ResponseEntity.ok(ApiResponseDto.success(null));
     }
 

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateCommandRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateCommandRedisAdapter.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CandidateCommandRedisAdapter implements SaveCandidatePort {
 
-    private static final String CANDIDATE_KEY_FORMAT = "vote:%s:candidates";
+    private static final String CANDIDATE_KEY_FORMAT = "candidate:%s";
 
     private final RedisTemplate<String, Object> redisTemplate;
 

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateQueryRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateQueryRedisAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CandidateQueryRedisAdapter implements LoadCandidatePort {
 
-    private static final String CANDIDATE_KEY_FORMAT = "vote:%s:candidates";
+    private static final String CANDIDATE_KEY_FORMAT = "candidate:%s";
 
     private final RedisTemplate<String, Object> redisTemplate;
 

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
@@ -18,15 +18,15 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
-    private static final String CANDIDATE_VOTE_KEY_FORMAT = "vote:%s:candidate:%d:%s";
+    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
+    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
 
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
-    public void saveByCandidate(Vote vote) {
-        String key = getCandidateVoteKey(vote);
-        RedisExecutor.runOrThrow("saveByCandidate", () ->
+    public void saveByVoteStatus(Vote vote) {
+        String key = getVoteStatusVoteKey(vote);
+        RedisExecutor.runOrThrow("saveByVoteStatus", () ->
             redisTemplate.opsForSet().add(key, vote.getMemberId())
         );
     }
@@ -55,7 +55,7 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
 
     @Override
     public void deleteByCandidate(Vote vote) {
-        String key = getCandidateVoteKey(vote);
+        String key = getVoteStatusVoteKey(vote);
         RedisExecutor.runOrThrow("deleteByCandidate", () -> {
             Long result = redisTemplate.opsForSet().remove(key, vote.getMemberId());
             if (isNotRemoved(result)) {
@@ -91,8 +91,8 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
         return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
     }
 
-    private String getCandidateVoteKey(Vote vote) {
-        return String.format(CANDIDATE_VOTE_KEY_FORMAT, vote.getRoomId(), vote.getStationId(),
-            vote.getVoteStatus().getName());
+    private String getVoteStatusVoteKey(Vote vote) {
+        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT,
+            vote.getVoteStatus().getName(), vote.getRoomId(), vote.getStationId());
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
@@ -5,9 +5,7 @@ import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.port.out.DeleteVotePort;
 import com.kok.kokcore.vote.port.out.SaveVotePort;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,32 +16,44 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
-    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
-
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
-    public void saveByVoteStatus(Vote vote) {
-        String key = getVoteStatusVoteKey(vote);
-        RedisExecutor.runOrThrow("saveByVoteStatus", () ->
+    public void saveVoteMemberHash(List<Vote> votes) {
+        validate(votes);
+        String roomId = votes.getFirst().getRoomId();
+        String memberId = votes.getFirst().getMemberId();
+        String memberHashKey = VoteKey.memberKey(roomId, memberId);
+        RedisExecutor.runOrThrow("saveVoteMemberHash", () -> {
+            for (Vote vote : votes) {
+                String field = VoteKey.stationField(vote.getStationId());
+                String status = vote.getVoteStatus().getName();
+                redisTemplate.opsForHash().put(memberHashKey, field, status);
+            }
+        });
+    }
+
+    @Override
+    public void saveVotedMemberSet(String roomId, String memberId) {
+        String votedMemberSetKey = VoteKey.voteKey(roomId);
+        RedisExecutor.runOrThrow("saveVotedMemberSet", () ->
+            redisTemplate.opsForSet().add(votedMemberSetKey, memberId)
+        );
+    }
+
+    @Override
+    public void saveVoteStatusSet(Vote vote) {
+        String key = VoteKey.voteStatusMemberSetKey(vote);
+        RedisExecutor.runOrThrow("saveVoteStatusSet", () ->
             redisTemplate.opsForSet().add(key, vote.getMemberId())
         );
     }
 
     @Override
-    public void saveAllByMember(List<Vote> votes) {
-        validate(votes);
-        String roomId = votes.getFirst().getRoomId();
-        String memberId = votes.getFirst().getMemberId();
-        String key = getMemberVoteKey(roomId, memberId);
-        Map<Long, String> value = votes.stream()
-            .collect(Collectors.toMap(
-                Vote::getStationId,
-                vote -> vote.getVoteStatus().getName()
-            ));
-        RedisExecutor.runOrThrow("saveAllByMember", () ->
-            redisTemplate.opsForHash().putAll(key, value)
+    public void incrementVoteStatusCountZSet(Vote vote) {
+        String key = VoteKey.voteStatusCountZSetKey(vote);
+        RedisExecutor.runOrThrow("incrementVoteStatusCountZSet", () ->
+            redisTemplate.opsForZSet().incrementScore(key, vote.getStationId(), 1)
         );
     }
 
@@ -54,45 +64,34 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
     }
 
     @Override
-    public void deleteByCandidate(Vote vote) {
-        String key = getVoteStatusVoteKey(vote);
-        RedisExecutor.runOrThrow("deleteByCandidate", () -> {
-            Long result = redisTemplate.opsForSet().remove(key, vote.getMemberId());
-            if (isNotRemoved(result)) {
-                log.warn(
-                    "Failed to remove memberId from candidate set or key not found: key={}, memberId={}",
-                    key,
-                    vote.getMemberId()
-                );
-            }
-        });
-    }
-
-    private static boolean isNotRemoved(Long removed) {
-        return Objects.isNull(removed) || removed == 0L;
+    public void removeMemberFromVoteStatusSet(Vote vote) {
+        String key = VoteKey.voteStatusMemberSetKey(vote);
+        RedisExecutor.runOrThrow("removeMemberFromVoteStatusSet", () ->
+            redisTemplate.opsForSet().remove(key, vote.getMemberId())
+        );
     }
 
     @Override
-    public void deleteAllByRoomIdAndMemberId(String roomId, String memberId) {
-        String key = getMemberVoteKey(roomId, memberId);
-        RedisExecutor.runOrThrow("deleteAllRoomIdAndMemberId", () -> {
-            Boolean result = redisTemplate.delete(key);
-            if (isNotRemoved(result)) {
-                log.warn("Key not found or already expired: {}", key);
-            }
-        });
+    public void decrementVoteCountInZSet(Vote vote) {
+        String key = VoteKey.voteStatusCountZSetKey(vote);
+        RedisExecutor.runOrThrow("decrementVoteCountInZSet", () ->
+            redisTemplate.opsForZSet().incrementScore(key, vote.getStationId(), -1)
+        );
     }
 
-    private static boolean isNotRemoved(Boolean result) {
-        return result.equals(Boolean.FALSE);
+    @Override
+    public void deleteMemberVoteHash(String roomId, String memberId) {
+        String key = VoteKey.memberKey(roomId, memberId);
+        RedisExecutor.runOrThrow("deleteMemberVoteHash", () ->
+            redisTemplate.delete(key)
+        );
     }
 
-    private String getMemberVoteKey(String roomId, String memberId) {
-        return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
-    }
-
-    private String getVoteStatusVoteKey(Vote vote) {
-        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT,
-            vote.getVoteStatus().getName(), vote.getRoomId(), vote.getStationId());
+    @Override
+    public void removeMemberFromVotedSet(String roomId, String memberId) {
+        String key = VoteKey.voteKey(roomId);
+        RedisExecutor.runOrThrow("removeMemberFromVotedSet", () ->
+            redisTemplate.opsForSet().remove(key, memberId)
+        );
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteKey.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteKey.java
@@ -1,0 +1,60 @@
+package com.kok.kokapi.vote.adapter.out.persistence;
+
+import com.kok.kokcore.vote.domain.Vote;
+import com.kok.kokcore.vote.domain.vo.VoteStatus;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum VoteKey {
+
+    VOTE_MEMBER_SET("vote:%s"),                             // Set<memberId>
+    MEMBER_HASH("member:%s:%s"),                      // Hash<stationId, voteStatus>
+    AGREE_COUNT_ZSET("agree:%s"),                      // ZSET<stationId, score>
+    AGREE_MEMBER_SET("agree:%s:%d"),                    // Set<memberId> per station
+    DISAGREE_COUNT_ZSET("disagree:%s"),                      // ZSET<stationId, score>
+    DISAGREE_MEMBER_SET("disagree:%s:%d");              // Set<memberId> per station
+
+    private final String format;
+
+    // 투표 완료자 목록 key
+    public static String voteKey(String roomId) {
+        return String.format(VOTE_MEMBER_SET.format, roomId);
+    }
+
+    // 멤버별 투표 상세 저장 key
+    public static String memberKey(String roomId, String memberId) {
+        return String.format(MEMBER_HASH.format, roomId, memberId);
+    }
+
+    // 찬성/반대 ZSET key (stationId별 투표 수 저장)
+    public static String voteStatusCountZSetKey(Vote vote) {
+        return vote.getVoteStatus().isAgree()
+            ? String.format(AGREE_COUNT_ZSET.format, vote.getRoomId())
+            : String.format(DISAGREE_COUNT_ZSET.format, vote.getRoomId());
+    }
+
+    public static String voteStatusCountZSetKey(VoteStatus voteStatus, String roomId) {
+        return voteStatus.isAgree()
+            ? String.format(AGREE_COUNT_ZSET.format, roomId)
+            : String.format(DISAGREE_COUNT_ZSET.format, roomId);
+    }
+
+    // 찬성/반대 Set key (stationId별 memberId 저장)
+    public static String voteStatusMemberSetKey(Vote vote) {
+        return vote.getVoteStatus().isAgree()
+            ? String.format(AGREE_MEMBER_SET.format, vote.getRoomId(), vote.getStationId())
+            : String.format(DISAGREE_MEMBER_SET.format, vote.getRoomId(), vote.getStationId());
+    }
+
+    public static String voteStatusMemberSetKey(
+        VoteStatus voteStatus, String roomId, long stationId) {
+        return voteStatus.isAgree()
+            ? String.format(AGREE_MEMBER_SET.format, roomId, stationId)
+            : String.format(DISAGREE_MEMBER_SET.format, roomId, stationId);
+    }
+
+    // 필드 이름으로 쓰일 stationId
+    public static String stationField(long stationId) {
+        return String.valueOf(stationId);
+    }
+}

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
@@ -2,6 +2,7 @@ package com.kok.kokapi.vote.adapter.out.persistence;
 
 import com.kok.kokapi.common.util.RedisExecutor;
 import com.kok.kokcore.vote.domain.Vote;
+import com.kok.kokcore.vote.domain.vo.VoteStatus;
 import com.kok.kokcore.vote.port.out.LoadVotePort;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Repository;
 public class VoteQueryRedisAdapter implements LoadVotePort {
 
     private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
+    private static final String CANDIDATE_VOTE_KEY_FORMAT = "vote:%s:candidate:%d:%s";
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -47,6 +49,11 @@ public class VoteQueryRedisAdapter implements LoadVotePort {
         }, List.of());
     }
 
+    @Override
+    public long getFirstStationIdByRoomIdAndVoteStatus(String roomId, VoteStatus voteStatus) {
+        return 0;
+    }
+
     private Long getStationId(Entry<Object, Object> voteInfo) {
         try {
             return Long.valueOf(voteInfo.getKey().toString());
@@ -58,5 +65,9 @@ public class VoteQueryRedisAdapter implements LoadVotePort {
 
     private String getMemberVoteKey(String roomId, String memberId) {
         return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
+    }
+
+    private String getCandidateVoteKey(String roomId, long stationId, VoteStatus status) {
+        return String.format(CANDIDATE_VOTE_KEY_FORMAT, roomId, stationId, status.getName());
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
@@ -18,8 +18,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class VoteQueryRedisAdapter implements LoadVotePort {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
-    private static final String CANDIDATE_VOTE_KEY_FORMAT = "vote:%s:candidate:%d:%s";
+    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
+    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -67,7 +67,7 @@ public class VoteQueryRedisAdapter implements LoadVotePort {
         return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
     }
 
-    private String getCandidateVoteKey(String roomId, long stationId, VoteStatus status) {
-        return String.format(CANDIDATE_VOTE_KEY_FORMAT, roomId, stationId, status.getName());
+    private String getVoteStatusVoteKey(VoteStatus status, String roomId, long stationId) {
+        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT, status.getName(), roomId, stationId);
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapter.java
@@ -8,12 +8,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 @Slf4j
@@ -21,15 +21,11 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class VoteQueryRedisAdapter implements LoadVotePort {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
-    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
-    private static final int MAX_COUNT = 20;
-
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public boolean isExistsByRoomIdAndMemberId(String roomId, String memberId) {
-        String key = getMemberVoteKey(roomId, memberId);
+        String key = VoteKey.memberKey(roomId, memberId);
         return RedisExecutor.runOrElseGet("isExistsByRoomIdAndMemberId", () ->
             !redisTemplate.opsForHash().entries(key).isEmpty(), false
         );
@@ -37,15 +33,12 @@ public class VoteQueryRedisAdapter implements LoadVotePort {
 
     @Override
     public List<Vote> findAllByRoomIdAndMemberId(String roomId, String memberId) {
-        String key = getMemberVoteKey(roomId, memberId);
+        String key = VoteKey.memberKey(roomId, memberId);
         return RedisExecutor.runOrElseGet("findAllByRoomIdAndMemberId", () -> {
             Map<Object, Object> voteInfos = redisTemplate.opsForHash().entries(key);
-            List<Vote> votes = new ArrayList<>(voteInfos.size());
+            List<Vote> votes = new ArrayList<>();
             for (Entry<Object, Object> voteInfo : voteInfos.entrySet()) {
                 Long stationId = getStationId(voteInfo);
-                if (stationId == null) {
-                    continue;
-                }
                 String voteStatus = String.valueOf(voteInfo.getValue());
                 votes.add(new Vote(roomId, stationId, memberId, voteStatus));
             }
@@ -55,56 +48,49 @@ public class VoteQueryRedisAdapter implements LoadVotePort {
 
     @Override
     public int countMembersByRoomId(String roomId) {
-        String pattern = getMemberVoteKey(roomId, "*");
         return RedisExecutor.runOrElseGet("countMembersByRoomId", () -> {
-            int count = 0;
-            ScanOptions options = ScanOptions.scanOptions()
-                .match(pattern)
-                .count(MAX_COUNT)
-                .build();
-
-            try (Cursor<String> cursor = redisTemplate.scan(options)) {
-                while (cursor.hasNext()) {
-                    count++;
-                    cursor.next();
-                }
-            }
-
-            return count;
+            String key = VoteKey.voteKey(roomId);
+            Long count = redisTemplate.opsForSet().size(key);
+            return Objects.nonNull(count) ? count.intValue() : 0;
         }, 0);
     }
 
     @Override
     public List<String> findMemberIdsByRoomIdAndStationIdAndStatus(
         String roomId, long stationId, VoteStatus voteStatus) {
-        String key = getVoteStatusVoteKey(voteStatus, roomId, stationId);
+        String key = VoteKey.voteStatusMemberSetKey(voteStatus, roomId, stationId);
         Set<Object> memberIds = RedisExecutor.runOrElseGet(
             "findMembersByRoomIdAndStationIdAndStatus",
-            () -> redisTemplate.opsForSet().members(key),
-            Set.of()
-        );
+            () -> redisTemplate.opsForSet().members(key), Set.of());
         return memberIds.stream().map(memberId -> (String) memberId).toList();
     }
 
     @Override
     public long getFirstStationIdByRoomIdAndVoteStatus(String roomId, VoteStatus voteStatus) {
-        return 0;
+        return RedisExecutor.runOrElseGet("getFirstStationIdByRoomIdAndVoteStatus", () -> {
+            String key = VoteKey.voteStatusCountZSetKey(voteStatus, roomId);
+            Set<ZSetOperations.TypedTuple<Object>> sorted =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, 0);
+
+            if (Objects.isNull(sorted) || sorted.isEmpty()) {
+                return -1L;
+            }
+
+            Object maxScoredStationId = sorted.iterator().next().getValue();
+            return getStationId(String.valueOf(maxScoredStationId));
+        }, -1L);
     }
 
     private Long getStationId(Entry<Object, Object> voteInfo) {
+        return getStationId(voteInfo.getKey().toString());
+    }
+
+    private Long getStationId(String stationId) {
         try {
-            return Long.valueOf(voteInfo.getKey().toString());
+            return Long.valueOf(stationId);
         } catch (NumberFormatException e) {
-            log.warn("Invalid stationId format in Redis: {}", voteInfo.getKey(), e);
-            return null;
+            log.warn("Invalid stationId format in Redis: {}", stationId, e);
+            throw new IllegalArgumentException("Invalid stationId format: " + stationId);
         }
-    }
-
-    private String getMemberVoteKey(String roomId, String memberId) {
-        return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
-    }
-
-    private String getVoteStatusVoteKey(VoteStatus status, String roomId, long stationId) {
-        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT, status.getName(), roomId, stationId);
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
@@ -15,7 +15,6 @@ import com.kok.kokcore.station.domain.entity.Route;
 import com.kok.kokcore.station.domain.entity.Station;
 import com.kok.kokcore.station.usecase.GetStationUseCase;
 import com.kok.kokcore.station.usecase.RetrieveRouteUseCase;
-import com.kok.kokcore.vote.domain.Candidate;
 import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.usecase.GetCandidateUseCase;
 import com.kok.kokcore.vote.usecase.GetVoteUseCase;
@@ -23,6 +22,7 @@ import com.kok.kokcore.vote.usecase.SaveVoteUseCase;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -40,16 +40,32 @@ public class VoteFacadeService {
     private final SaveVoteUseCase saveVoteUseCase;
 
     public List<CandidateResponse> getCandidates(
-        String roomId, String memberId, List<Station> stations) {
-        List<Candidate> candidates = getCandidateUseCase.saveAndGetCandidates(roomId, stations);
+        String roomId, String memberId,
+        List<Station> recommendedStations,
+        List<Station> customStations) {
+        List<Station> allStations = Stream.concat(
+            recommendedStations.stream(), customStations.stream()
+        ).toList();
+        getCandidateUseCase.saveAndGetCandidates(roomId, allStations);
+
         List<CandidateResponse> responses = new ArrayList<>();
-        for (Candidate candidate : candidates) {
-            Station station = getStationUseCase.getStation(candidate.getStationId());
+        responses.addAll(createCandidateResponses(recommendedStations, roomId, memberId, true));
+        responses.addAll(createCandidateResponses(customStations, roomId, memberId, false));
+
+        return responses;
+    }
+
+
+    private List<CandidateResponse> createCandidateResponses(
+        List<Station> stations, String roomId, String memberId, boolean isRecommended) {
+        List<CandidateResponse> responses = new ArrayList<>();
+        for (Station station : stations) {
             List<Route> routes = retrieveRouteUseCase.retrieveRoutes(station);
-            TmapPublicTransportationParsedResponse transportationParsedResponse = getTransportationParsedResponse(
+            TmapPublicTransportationParsedResponse transportation = getTransportationParsedResponse(
                 roomId, memberId, station);
-            CandidateResponse response = CandidateResponse.of(
-                station, routes, transportationParsedResponse, List.of());
+            CandidateResponse response = isRecommended
+                ? CandidateResponse.recommended(station, routes, transportation, List.of())
+                : CandidateResponse.custom(station, routes, transportation, List.of());
             responses.add(response);
         }
         return responses;

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
@@ -8,6 +8,8 @@ import com.kok.kokapi.vote.adapter.in.dto.response.CandidateResponse;
 import com.kok.kokapi.vote.adapter.in.dto.response.MemberVoteStatusResponse;
 import com.kok.kokapi.vote.adapter.in.dto.response.ResultResponse;
 import com.kok.kokapi.vote.adapter.in.dto.response.VoteResultResponse;
+import com.kok.kokcore.location.domain.Location;
+import com.kok.kokcore.location.usecase.ReadLocationUseCase;
 import com.kok.kokcore.room.domain.Member;
 import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.room.usecase.GetRoomUseCase;
@@ -38,6 +40,7 @@ public class VoteFacadeService {
     private final TmapPublicTransportationService tmapPublicTransportationService;
     private final ObjectMapper objectMapper;
     private final SaveVoteUseCase saveVoteUseCase;
+    private final ReadLocationUseCase readLocationUseCase;
 
     public List<CandidateResponse> getCandidates(
         String roomId, String memberId,
@@ -91,7 +94,9 @@ public class VoteFacadeService {
         List<MemberVoteStatusResponse> responses = new ArrayList<>();
         for (Member member : members) {
             boolean isVoted = getVoteUseCase.isVotedByMember(roomId, member.getMemberId());
-            MemberVoteStatusResponse response = MemberVoteStatusResponse.of(member, isVoted);
+            Location location = readLocationUseCase.readLocation(roomId, member.getMemberId());
+            MemberVoteStatusResponse response = MemberVoteStatusResponse.of(
+                member, location, isVoted);
             responses.add(response);
         }
         return responses;

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
@@ -19,6 +19,7 @@ import com.kok.kokcore.vote.domain.Candidate;
 import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.usecase.GetCandidateUseCase;
 import com.kok.kokcore.vote.usecase.GetVoteUseCase;
+import com.kok.kokcore.vote.usecase.SaveVoteUseCase;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,7 @@ public class VoteFacadeService {
     private final GetRoomUseCase getRoomUseCase;
     private final TmapPublicTransportationService tmapPublicTransportationService;
     private final ObjectMapper objectMapper;
+    private final SaveVoteUseCase saveVoteUseCase;
 
     public List<CandidateResponse> getCandidates(
         String roomId, String memberId, List<Station> stations) {
@@ -91,5 +93,11 @@ public class VoteFacadeService {
             responses.add(response);
         }
         return new VoteResultResponse(room.getNotVotedCount(votedCount), responses);
+    }
+
+    public void saveVotes(
+        String roomId, String memberId, List<Long> agreedStationIds, List<Station> stations) {
+        getCandidateUseCase.saveAndGetCandidates(roomId, stations);
+        saveVoteUseCase.saveVotes(roomId, memberId, agreedStationIds);
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteFacadeService.java
@@ -37,8 +37,8 @@ public class VoteFacadeService {
     private final TmapPublicTransportationService tmapPublicTransportationService;
     private final ObjectMapper objectMapper;
 
-    public List<CandidateResponse> getCandidates(String roomId, String memberId,
-        List<Station> stations) {
+    public List<CandidateResponse> getCandidates(
+        String roomId, String memberId, List<Station> stations) {
         List<Candidate> candidates = getCandidateUseCase.saveAndGetCandidates(roomId, stations);
         List<CandidateResponse> responses = new ArrayList<>();
         for (Candidate candidate : candidates) {

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -36,6 +36,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     @Override
     public void saveVotes(String roomId, String memberId, List<Long> agreedStationIds) {
         validate(roomId, memberId);
+        validateRoomStatusIfNotOnVote(roomId);
         initiate(roomId, memberId);
         List<Vote> votes = getVotes(roomId, memberId, agreedStationIds);
         // 1. 멤버의 투표 내용 Hash 저장
@@ -89,6 +90,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     @Override
     public int countVotedMembers(String roomId) {
         validate(roomId);
+        validateRoomStatusIfNotOnVote(roomId);
         return loadVotePort.countMembersByRoomId(roomId);
     }
 
@@ -117,9 +119,9 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     public Station getVoteFinalResult(String roomId) {
         validate(roomId);
         Room room = getRoom(roomId);
-        validateRoomStatus(room);
-        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(roomId,
-            VoteStatus.AGREE);
+        validateRoomStatusIfVoteClosed(room);
+        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(
+            roomId, VoteStatus.AGREE);
         return retrieveStationsPort.retrieveStation(stationId)
             .orElseThrow(
                 () -> new IllegalArgumentException("Station not found with id " + stationId));
@@ -141,6 +143,9 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         if (!loadRoomPort.isExistsByRoomId(roomId)) {
             throw new IllegalArgumentException("Room not found with id: " + roomId);
         }
+    }
+
+    private void validateRoomStatusIfNotOnVote(String roomId) {
         Room room = getRoom(roomId);
         if (room.isNotOnVote()) {
             throw new IllegalStateException(
@@ -161,7 +166,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
             .orElseThrow(() -> new IllegalArgumentException("Room not found with id: " + roomId));
     }
 
-    private static void validateRoomStatus(Room room) {
+    private static void validateRoomStatusIfVoteClosed(Room room) {
         if (!room.isVoteClosed()) {
             throw new IllegalArgumentException(
                 "Vote is not closed for room with id: " + room.getId());

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -3,7 +3,9 @@ package com.kok.kokapi.vote.application.service;
 import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.room.port.out.LoadRoomPort;
 import com.kok.kokcore.station.domain.entity.Station;
+import com.kok.kokcore.station.port.out.RetrieveStationsPort;
 import com.kok.kokcore.vote.domain.Vote;
+import com.kok.kokcore.vote.domain.vo.VoteStatus;
 import com.kok.kokcore.vote.port.out.DeleteVotePort;
 import com.kok.kokcore.vote.port.out.LoadVotePort;
 import com.kok.kokcore.vote.port.out.SaveVotePort;
@@ -21,6 +23,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     private final LoadVotePort loadVotePort;
     private final DeleteVotePort deleteVotePort;
     private final LoadRoomPort loadRoomPort;
+    private final RetrieveStationsPort retrieveStationsPort;
 
     @Override
     public void saveVotes(List<Vote> votes) {
@@ -51,7 +54,12 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         Room room = loadRoomPort.findRoomById(roomId)
             .orElseThrow(() -> new IllegalArgumentException("Cannot find room with id: " + roomId));
         validateRoomStatus(room);
-        return null;
+        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(roomId,
+            VoteStatus.AGREE);
+        Station station = retrieveStationsPort.retrieveStation(stationId)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Cannot find station with id " + stationId));
+        return station;
     }
 
     private static void validateRoomStatus(Room room) {

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -32,7 +32,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         initiate(roomId, memberId);
         saveVotePort.saveAllByMember(votes);
         for (Vote vote : votes) {
-            saveVotePort.saveByCandidate(vote);
+            saveVotePort.saveByVoteStatus(vote);
         }
     }
 
@@ -54,8 +54,8 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         Room room = loadRoomPort.findRoomById(roomId)
             .orElseThrow(() -> new IllegalArgumentException("Cannot find room with id: " + roomId));
         validateRoomStatus(room);
-        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(roomId,
-            VoteStatus.AGREE);
+        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(
+            roomId, VoteStatus.AGREE);
         Station station = retrieveStationsPort.retrieveStation(stationId)
             .orElseThrow(
                 () -> new IllegalArgumentException("Cannot find station with id " + stationId));

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -1,5 +1,8 @@
 package com.kok.kokapi.vote.application.service;
 
+import com.kok.kokcore.room.domain.Room;
+import com.kok.kokcore.room.port.out.LoadRoomPort;
+import com.kok.kokcore.station.domain.entity.Station;
 import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.port.out.DeleteVotePort;
 import com.kok.kokcore.vote.port.out.LoadVotePort;
@@ -17,6 +20,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     private final SaveVotePort saveVotePort;
     private final LoadVotePort loadVotePort;
     private final DeleteVotePort deleteVotePort;
+    private final LoadRoomPort loadRoomPort;
 
     @Override
     public void saveVotes(List<Vote> votes) {
@@ -40,5 +44,20 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     @Override
     public boolean isVotedByMember(String roomId, String memberId) {
         return loadVotePort.isExistsByRoomIdAndMemberId(roomId, memberId);
+    }
+
+    @Override
+    public Station getVoteFinalResult(String roomId) {
+        Room room = loadRoomPort.findRoomById(roomId)
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find room with id: " + roomId));
+        validateRoomStatus(room);
+        return null;
+    }
+
+    private static void validateRoomStatus(Room room) {
+        if (!room.isVoteClosed()) {
+            throw new IllegalArgumentException(
+                "Vote is not closed for room with id: " + room.getId());
+        }
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -38,9 +38,16 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         validate(roomId, memberId);
         initiate(roomId, memberId);
         List<Vote> votes = getVotes(roomId, memberId, agreedStationIds);
-        saveVotePort.saveAllByMember(votes);
+        // 1. 멤버의 투표 내용 Hash 저장
+        saveVotePort.saveVoteMemberHash(votes);
+
+        // 2. 투표 완료 Set에 멤버 추가
+        saveVotePort.saveVotedMemberSet(roomId, memberId);
+
+        // 3. 각 후보에 대한 Set/ZSet 업데이트
         for (Vote vote : votes) {
-            saveVotePort.saveByVoteStatus(vote);
+            saveVotePort.saveVoteStatusSet(vote);
+            saveVotePort.incrementVoteStatusCountZSet(vote);
         }
     }
 
@@ -64,8 +71,13 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
     private void initiate(String roomId, String memberId) {
         if (loadVotePort.isExistsByRoomIdAndMemberId(roomId, memberId)) {
             List<Vote> votes = loadVotePort.findAllByRoomIdAndMemberId(roomId, memberId);
-            votes.forEach(deleteVotePort::deleteByCandidate);
-            deleteVotePort.deleteAllByRoomIdAndMemberId(roomId, memberId);
+            for (Vote vote : votes) {
+                deleteVotePort.removeMemberFromVoteStatusSet(vote);
+                deleteVotePort.decrementVoteCountInZSet(vote);
+            }
+
+            deleteVotePort.deleteMemberVoteHash(roomId, memberId);
+            deleteVotePort.removeMemberFromVotedSet(roomId, memberId);
         }
     }
 
@@ -101,6 +113,18 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
             .toList();
     }
 
+    @Override
+    public Station getVoteFinalResult(String roomId) {
+        validate(roomId);
+        Room room = getRoom(roomId);
+        validateRoomStatus(room);
+        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(roomId,
+            VoteStatus.AGREE);
+        return retrieveStationsPort.retrieveStation(stationId)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Station not found with id " + stationId));
+    }
+
     private void validate(String roomId, String memberId) {
         validate(roomId);
         List<String> memberIds = loadRoomParticipantPort.findMembersByRoomId(roomId).stream()
@@ -108,14 +132,14 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
             .toList();
         if (!memberIds.contains(memberId)) {
             throw new IllegalArgumentException(
-                String.format("Cannot find member with id: %s, in room with id: %s", memberId,
-                    roomId));
+                String.format("Member not found with id: %s, in room with id: %s",
+                    memberId, roomId));
         }
     }
 
     private void validate(String roomId) {
         if (!loadRoomPort.isExistsByRoomId(roomId)) {
-            throw new IllegalArgumentException("Cannot find room with roomId: " + roomId);
+            throw new IllegalArgumentException("Room not found with id: " + roomId);
         }
         Room room = getRoom(roomId);
         if (room.isNotOnVote()) {
@@ -124,30 +148,17 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
         }
     }
 
-    private Room getRoom(String roomId) {
-        return loadRoomPort.findRoomById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("Room not found with id: " + roomId));
-    }
-
     private void validateVote(String roomId, String memberId) {
         if (!loadVotePort.isExistsByRoomIdAndMemberId(roomId, memberId)) {
             throw new IllegalArgumentException(
-                String.format("Not voted by member with id: %s, in room with id: %s", memberId,
-                    roomId));
+                String.format("Not voted by member with id: %s, in room with id: %s",
+                    memberId, roomId));
         }
     }
 
-    @Override
-    public Station getVoteFinalResult(String roomId) {
-        Room room = loadRoomPort.findRoomById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("Cannot find room with id: " + roomId));
-        validateRoomStatus(room);
-        long stationId = loadVotePort.getFirstStationIdByRoomIdAndVoteStatus(
-            roomId, VoteStatus.AGREE);
-        Station station = retrieveStationsPort.retrieveStation(stationId)
-            .orElseThrow(
-                () -> new IllegalArgumentException("Cannot find station with id " + stationId));
-        return station;
+    private Room getRoom(String roomId) {
+        return loadRoomPort.findRoomById(roomId)
+            .orElseThrow(() -> new IllegalArgumentException("Room not found with id: " + roomId));
     }
 
     private static void validateRoomStatus(Room room) {

--- a/kok-api/src/main/resources/application-dev.yml
+++ b/kok-api/src/main/resources/application-dev.yml
@@ -1,4 +1,6 @@
 spring:
+  jackson:
+    time-zone: UTC
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/kok-api/src/main/resources/application-prod.yml
+++ b/kok-api/src/main/resources/application-prod.yml
@@ -1,4 +1,6 @@
 spring:
+  jackson:
+    time-zone: UTC
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateCommandRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateCommandRedisAdapterTest.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class CandidateCommandRedisAdapterTest extends RepositoryTest {
 
-    private static final String CANDIDATE_KEY_FORMAT = "vote:%s:candidates";
+    private static final String CANDIDATE_KEY_FORMAT = "candidate:%s";
 
     @Autowired
     private CandidateCommandRedisAdapter candidateCommandRedisAdapter;

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateQueryRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/CandidateQueryRedisAdapterTest.java
@@ -12,7 +12,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class CandidateQueryRedisAdapterTest extends RepositoryTest {
 
-    private static final String CANDIDATE_KEY_FORMAT = "vote:%s:candidates";
+    private static final String CANDIDATE_KEY_FORMAT = "candidate:%s";
 
     @Autowired
     private CandidateQueryRedisAdapter candidateQueryRedisAdapter;

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapterTest.java
@@ -17,122 +17,145 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteCommandRedisAdapterTest extends RepositoryTest {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
-    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
-
     @Autowired
     private VoteCommandRedisAdapter voteCommandRedisAdapter;
+
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
 
-    @DisplayName("후보별로 사용자의 투표 정보를 저장한다.")
     @Test
-    void saveVoteByCandidate() {
-        // given
-        String existingMemberId = "memberId2";
-        String memberId = "memberId";
-        Candidate candidate = new Candidate("roomId", 1);
-        Vote vote = new Vote(candidate, memberId, VoteStatus.AGREE);
-        String key = getVoteStatusVoteKey(vote);
-        redisTemplate.opsForSet().add(key, existingMemberId);
-
-        // when
-        voteCommandRedisAdapter.saveByVoteStatus(vote);
-
-        // then
-        Set<Object> memberIds = redisTemplate.opsForSet().members(key);
-        assertThat(memberIds).containsExactlyInAnyOrder(existingMemberId, memberId);
-    }
-
-    @DisplayName("사용자의 투표 결과를 저장한다.")
-    @Test
-    void saveAllByCandidateVotesOfMember() {
+    @DisplayName("멤버별 투표 내용을 Hash로 저장한다.")
+    void saveVoteMemberHash() {
         // given
         String roomId = "roomId";
         String memberId = "memberId";
-        Candidate candidate = new Candidate(roomId, 1);
-        Candidate candidate2 = new Candidate(roomId, 2);
-        Candidate candidate3 = new Candidate(roomId, 3);
         List<Vote> votes = List.of(
-            new Vote(candidate, memberId, VoteStatus.AGREE),
-            new Vote(candidate2, memberId, VoteStatus.DISAGREE),
-            new Vote(candidate3, memberId, VoteStatus.DISAGREE)
+            new Vote(new Candidate(roomId, 1), memberId, VoteStatus.AGREE),
+            new Vote(new Candidate(roomId, 2), memberId, VoteStatus.DISAGREE)
         );
 
         // when
-        voteCommandRedisAdapter.saveAllByMember(votes);
+        voteCommandRedisAdapter.saveVoteMemberHash(votes);
 
         // then
-        Map<Object, Object> result = redisTemplate.opsForHash()
-            .entries(getMemberVoteKey(roomId, memberId));
-        assertThat(result).containsAllEntriesOf(
-            Map.of(
-                votes.get(0).getStationId(), votes.get(0).getVoteStatus().getName(),
-                votes.get(1).getStationId(), votes.get(1).getVoteStatus().getName(),
-                votes.get(2).getStationId(), votes.get(2).getVoteStatus().getName()
-            )
-        );
+        String key = VoteKey.memberKey(roomId, memberId);
+        Map<Object, Object> result = redisTemplate.opsForHash().entries(key);
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+            "1", VoteStatus.AGREE.getName(),
+            "2", VoteStatus.DISAGREE.getName()));
     }
 
-    @DisplayName("후보별로 사용자의 투표 정보를 삭제한다.")
     @Test
-    void deleteVoteByCandidate() {
-        // given
-        String memberId = "memberId";
-        String memberId2 = "memberId2";
-        Candidate candidate = new Candidate("roomId", 1);
-        Vote vote = new Vote(candidate, memberId, VoteStatus.AGREE);
-        String key = getVoteStatusVoteKey(vote);
-        redisTemplate.opsForSet().add(key, memberId, memberId2);
-
-        // when
-        voteCommandRedisAdapter.deleteByCandidate(vote);
-
-        // then
-        Set<Object> memberIds = redisTemplate.opsForSet().members(key);
-        assertThat(memberIds).containsExactlyInAnyOrder(memberId2);
-    }
-
-    @DisplayName("사용자의 투표 정보를 삭제한다.")
-    @Test
-    void deleteAllByRoomIdAndMemberId() {
+    @DisplayName("투표 완료자 Set에 멤버를 저장한다.")
+    void saveVotedMemberSet() {
         // given
         String roomId = "roomId";
         String memberId = "memberId";
-        Candidate candidate = new Candidate(roomId, 1);
-        Candidate candidate2 = new Candidate(roomId, 2);
-        Candidate candidate3 = new Candidate(roomId, 3);
-        String key = getMemberVoteKey(roomId, memberId);
-        List<Vote> votes = List.of(
-            new Vote(candidate, memberId, VoteStatus.AGREE),
-            new Vote(candidate2, memberId, VoteStatus.DISAGREE),
-            new Vote(candidate3, memberId, VoteStatus.DISAGREE)
-        );
-        redisTemplate.opsForHash().putAll(key, Map.of(
-            votes.get(0).getStationId(), votes.get(0).getVoteStatus().getName(),
-            votes.get(1).getStationId(), votes.get(1).getVoteStatus().getName(),
-            votes.get(2).getStationId(), votes.get(2).getVoteStatus().getName()
-        ));
-        Long before = redisTemplate.opsForHash().size(key);
 
         // when
-        voteCommandRedisAdapter.deleteAllByRoomIdAndMemberId(roomId, memberId);
+        voteCommandRedisAdapter.saveVotedMemberSet(roomId, memberId);
 
         // then
-        Long after = redisTemplate.opsForHash().size(key);
+        Set<Object> result = redisTemplate.opsForSet().members(VoteKey.voteKey(roomId));
+        assertThat(result).containsExactlyInAnyOrder(memberId);
+    }
+
+    @Test
+    @DisplayName("찬/반 Set에 멤버를 저장한다.")
+    void saveVoteStatusSet() {
+        // given
+        Vote vote = new Vote(new Candidate("roomId", 100), "memberId", VoteStatus.AGREE);
+
+        // when
+        voteCommandRedisAdapter.saveVoteStatusSet(vote);
+
+        // then
+        Set<Object> result = redisTemplate.opsForSet()
+            .members(VoteKey.voteStatusMemberSetKey(vote));
+        assertThat(result).containsExactlyInAnyOrder("memberId");
+    }
+
+    @Test
+    @DisplayName("ZSet에 찬/반 득표수를 1 증가시킨다.")
+    void incrementVoteStatusCountZSet() {
+        // given
+        Vote vote = new Vote(new Candidate("roomId", 100), "memberId", VoteStatus.AGREE);
+
+        // when
+        voteCommandRedisAdapter.incrementVoteStatusCountZSet(vote);
+
+        // then
+        Double score = redisTemplate.opsForZSet()
+            .score(VoteKey.voteStatusCountZSetKey(vote), vote.getStationId());
+
+        assertThat(score).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("ZSet에서 득표수를 1 감소시킨다.")
+    void decrementVoteCountInZSet() {
+        // given
+        Vote vote = new Vote(new Candidate("roomId", 100), "memberId", VoteStatus.AGREE);
+        String key = VoteKey.voteStatusCountZSetKey(vote);
+        redisTemplate.opsForZSet().add(key, vote.getStationId(), 2.0);
+
+        // when
+        voteCommandRedisAdapter.decrementVoteCountInZSet(vote);
+
+        // then
+        Double score = redisTemplate.opsForZSet().score(key, vote.getStationId());
+        assertThat(score).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("찬/반 Set에서 멤버를 제거한다.")
+    void removeMemberFromVoteStatusSet() {
+        // given
+        Vote vote = new Vote(new Candidate("roomId", 100), "memberId", VoteStatus.AGREE);
+        String key = VoteKey.voteStatusMemberSetKey(vote);
+        redisTemplate.opsForSet().add(key, "memberId");
+
+        // when
+        voteCommandRedisAdapter.removeMemberFromVoteStatusSet(vote);
+
+        // then
+        Set<Object> result = redisTemplate.opsForSet().members(key);
+        assertThat(result).doesNotContain("memberId");
+    }
+
+    @Test
+    @DisplayName("멤버 투표 Hash를 삭제한다.")
+    void deleteMemberVoteHash() {
+        // given
+        String roomId = "roomId";
+        String memberId = "memberId";
+        String key = VoteKey.memberKey(roomId, memberId);
+        redisTemplate.opsForHash().put(key, "1", "AGREE");
+
+        // when
+        voteCommandRedisAdapter.deleteMemberVoteHash(roomId, memberId);
+
+        // then
         assertAll(
-            () -> assertThat(before).isEqualTo(3),
-            () -> assertThat(after).isEqualTo(0),
-            () -> assertThat(redisTemplate.hasKey(key)).isFalse()
+            () -> assertThat(redisTemplate.hasKey(key)).isFalse(),
+            () -> assertThat(redisTemplate.opsForHash().size(key)).isZero()
         );
     }
 
-    private String getVoteStatusVoteKey(Vote vote) {
-        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT,
-            vote.getVoteStatus().getName(), vote.getRoomId(), vote.getStationId());
-    }
+    @Test
+    @DisplayName("투표 완료자 Set에서 멤버를 제거한다.")
+    void removeMemberFromVotedSet() {
+        // given
+        String roomId = "roomId";
+        String memberId = "memberId";
+        String key = VoteKey.voteKey(roomId);
+        redisTemplate.opsForSet().add(key, memberId);
 
-    private String getMemberVoteKey(String roomId, String memberId) {
-        return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
+        // when
+        voteCommandRedisAdapter.removeMemberFromVotedSet(roomId, memberId);
+
+        // then
+        Set<Object> result = redisTemplate.opsForSet().members(key);
+        assertThat(result).doesNotContain(memberId);
     }
 }

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapterTest.java
@@ -17,8 +17,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteCommandRedisAdapterTest extends RepositoryTest {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
-    private static final String CANDIDATE_VOTE_KEY_FORMAT = "vote:%s:candidate:%d:%s";
+    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
+    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
 
     @Autowired
     private VoteCommandRedisAdapter voteCommandRedisAdapter;
@@ -33,11 +33,11 @@ class VoteCommandRedisAdapterTest extends RepositoryTest {
         String memberId = "memberId";
         Candidate candidate = new Candidate("roomId", 1);
         Vote vote = new Vote(candidate, memberId, VoteStatus.AGREE);
-        String key = getCandidateVoteKey(vote);
+        String key = getVoteStatusVoteKey(vote);
         redisTemplate.opsForSet().add(key, existingMemberId);
 
         // when
-        voteCommandRedisAdapter.saveByCandidate(vote);
+        voteCommandRedisAdapter.saveByVoteStatus(vote);
 
         // then
         Set<Object> memberIds = redisTemplate.opsForSet().members(key);
@@ -82,7 +82,7 @@ class VoteCommandRedisAdapterTest extends RepositoryTest {
         String memberId2 = "memberId2";
         Candidate candidate = new Candidate("roomId", 1);
         Vote vote = new Vote(candidate, memberId, VoteStatus.AGREE);
-        String key = getCandidateVoteKey(vote);
+        String key = getVoteStatusVoteKey(vote);
         redisTemplate.opsForSet().add(key, memberId, memberId2);
 
         // when
@@ -127,9 +127,9 @@ class VoteCommandRedisAdapterTest extends RepositoryTest {
         );
     }
 
-    private String getCandidateVoteKey(Vote vote) {
-        return String.format(CANDIDATE_VOTE_KEY_FORMAT, vote.getRoomId(), vote.getStationId(),
-            vote.getVoteStatus().getName());
+    private String getVoteStatusVoteKey(Vote vote) {
+        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT,
+            vote.getVoteStatus().getName(), vote.getRoomId(), vote.getStationId());
     }
 
     private String getMemberVoteKey(String roomId, String memberId) {

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
@@ -14,21 +14,20 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteQueryRedisAdapterTest extends RepositoryTest {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
-
     @Autowired
     private VoteQueryRedisAdapter voteQueryRedisAdapter;
+
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
 
-    @DisplayName("roomId와 memberId 조합으로 투표 정보가 존재하는지 확인한다.")
     @Test
+    @DisplayName("roomId와 memberId 조합으로 투표 정보가 존재하는지 확인한다.")
     void isExistsByRoomIdAndMemberId() {
         // given
-        String roomId = "roomId";
-        String memberId = "memberId";
-        String key = getMemberVoteKey(roomId, memberId);
-        redisTemplate.opsForHash().putAll(key, Map.of(1L, VoteStatus.AGREE.getName()));
+        String roomId = "room1";
+        String memberId = "memberA";
+        String key = VoteKey.memberKey(roomId, memberId);
+        redisTemplate.opsForHash().putAll(key, Map.of("1", "AGREE"));
 
         // when
         boolean result = voteQueryRedisAdapter.isExistsByRoomIdAndMemberId(roomId, memberId);
@@ -37,49 +36,40 @@ class VoteQueryRedisAdapterTest extends RepositoryTest {
         assertThat(result).isTrue();
     }
 
-    @DisplayName("해당 roomId와 memberId 조합으로 투표 정보가 없으면 false를 반환한다.")
     @Test
+    @DisplayName("투표 정보가 없으면 false를 반환한다.")
     void isNotExistsByRoomIdAndMemberId() {
-        // given
-        String roomId = "roomId";
-        String memberId = "memberId";
-
-        // when
-        boolean result = voteQueryRedisAdapter.isExistsByRoomIdAndMemberId(roomId, memberId);
-
-        // then
-        assertThat(result).isFalse();
+        assertThat(voteQueryRedisAdapter.isExistsByRoomIdAndMemberId("roomX", "memberY")).isFalse();
     }
 
-    @DisplayName("roomId와 memberId 조합으로 모든 투표 정보를 조회한다.")
     @Test
+    @DisplayName("roomId, memberId로 투표 전체 목록을 조회한다.")
     void findAllByRoomIdAndMemberId() {
         // given
-        String roomId = "roomId";
-        String memberId = "memberId";
-        String key = getMemberVoteKey(roomId, memberId);
+        String roomId = "room2";
+        String memberId = "memberB";
+        String key = VoteKey.memberKey(roomId, memberId);
         Vote vote = new Vote(roomId, 1L, memberId, VoteStatus.AGREE.getName());
-        redisTemplate.opsForHash()
-            .putAll(key, Map.of(vote.getStationId(), vote.getVoteStatus().getName()));
+        Vote vote2 = new Vote(roomId, 2L, memberId, VoteStatus.DISAGREE.getName());
+        redisTemplate.opsForHash().putAll(key, Map.of(
+            "1", VoteStatus.AGREE.getName(),
+            "2", VoteStatus.DISAGREE.getName()
+        ));
 
         // when
-        List<Vote> votes = voteQueryRedisAdapter.findAllByRoomIdAndMemberId(roomId, memberId);
+        List<Vote> result = voteQueryRedisAdapter.findAllByRoomIdAndMemberId(roomId, memberId);
 
         // then
-        assertThat(votes).containsExactlyInAnyOrder(vote);
+        assertThat(result).hasSize(2)
+            .containsExactlyInAnyOrder(vote, vote2);
     }
 
-    @DisplayName("roomId로 투표한 member 수를 반환한다.")
     @Test
+    @DisplayName("roomId에 대해 투표 완료한 멤버 수를 반환한다.")
     void countMembersByRoomId() {
         // given
-        String roomId = "roomId";
-        redisTemplate.opsForHash()
-            .putAll(getMemberVoteKey(roomId, "1"), Map.of(1L, VoteStatus.AGREE.getName()));
-        redisTemplate.opsForHash()
-            .putAll(getMemberVoteKey(roomId, "2"), Map.of(1L, VoteStatus.AGREE.getName()));
-        redisTemplate.opsForHash()
-            .putAll(getMemberVoteKey(roomId, "3"), Map.of(1L, VoteStatus.AGREE.getName()));
+        String roomId = "room3";
+        redisTemplate.opsForSet().add(VoteKey.voteKey(roomId), "member1", "member2", "member3");
 
         // when
         int count = voteQueryRedisAdapter.countMembersByRoomId(roomId);
@@ -88,8 +78,53 @@ class VoteQueryRedisAdapterTest extends RepositoryTest {
         assertThat(count).isEqualTo(3);
     }
 
-    private String getMemberVoteKey(String roomId, String memberId) {
-        return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
+    @Test
+    @DisplayName("특정 stationId에 대해 투표한 memberId 리스트를 조회한다.")
+    void findMemberIdsByRoomIdAndStationIdAndStatus() {
+        // given
+        String roomId = "room4";
+        long stationId = 11L;
+        String key = VoteKey.voteStatusMemberSetKey(VoteStatus.AGREE, roomId, stationId);
+        redisTemplate.opsForSet().add(key, "member1", "member2");
+
+        // when
+        List<String> result = voteQueryRedisAdapter.findMemberIdsByRoomIdAndStationIdAndStatus(
+            roomId, stationId, VoteStatus.AGREE);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("member1", "member2");
     }
 
+    @Test
+    @DisplayName("찬성 수가 가장 많은 stationId를 반환한다.")
+    void getFirstStationIdByRoomIdAndVoteStatus() {
+        // given
+        String roomId = "room5";
+        String key = VoteKey.voteStatusCountZSetKey(VoteStatus.AGREE, roomId);
+        redisTemplate.opsForZSet().add(key, "10", 5.0); // stationId 10 with 5 votes
+        redisTemplate.opsForZSet().add(key, "11", 8.0); // stationId 11 with 8 votes
+
+        // when
+        long result = voteQueryRedisAdapter.getFirstStationIdByRoomIdAndVoteStatus(
+            roomId, VoteStatus.AGREE);
+
+        // then
+        assertThat(result).isEqualTo(11);
+    }
+
+    @Test
+    @DisplayName("찬성 투표자가 아무도 없으면 -1을 반환한다.")
+    void getFirstStationIdWhenNoVotes() {
+        // given
+        String roomId = "room6";
+        String key = VoteKey.voteStatusCountZSetKey(VoteStatus.AGREE, roomId);
+        redisTemplate.delete(key);
+
+        // when
+        long result = voteQueryRedisAdapter.getFirstStationIdByRoomIdAndVoteStatus(
+            roomId, VoteStatus.AGREE);
+
+        // then
+        assertThat(result).isEqualTo(-1L);
+    }
 }

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
@@ -27,7 +27,7 @@ class VoteQueryRedisAdapterTest extends RepositoryTest {
         String roomId = "room1";
         String memberId = "memberA";
         String key = VoteKey.memberKey(roomId, memberId);
-        redisTemplate.opsForHash().putAll(key, Map.of("1", "AGREE"));
+        redisTemplate.opsForHash().putAll(key, Map.of("1", VoteStatus.AGREE.getName()));
 
         // when
         boolean result = voteQueryRedisAdapter.isExistsByRoomIdAndMemberId(roomId, memberId);
@@ -101,8 +101,8 @@ class VoteQueryRedisAdapterTest extends RepositoryTest {
         // given
         String roomId = "room5";
         String key = VoteKey.voteStatusCountZSetKey(VoteStatus.AGREE, roomId);
-        redisTemplate.opsForZSet().add(key, "10", 5.0); // stationId 10 with 5 votes
-        redisTemplate.opsForZSet().add(key, "11", 8.0); // stationId 11 with 8 votes
+        redisTemplate.opsForZSet().add(key, "10", 5.0);
+        redisTemplate.opsForZSet().add(key, "11", 8.0);
 
         // when
         long result = voteQueryRedisAdapter.getFirstStationIdByRoomIdAndVoteStatus(

--- a/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/adapter/out/persistence/VoteQueryRedisAdapterTest.java
@@ -14,7 +14,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteQueryRedisAdapterTest extends RepositoryTest {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
+    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
 
     @Autowired
     private VoteQueryRedisAdapter voteQueryRedisAdapter;

--- a/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
@@ -9,6 +9,7 @@ import com.kok.kokapi.fixture.MemberFixture;
 import com.kok.kokapi.room.adapter.out.persistence.RoomParticipantSaveAdapter;
 import com.kok.kokapi.room.adapter.out.persistence.RoomSaveRedisAdapter;
 import com.kok.kokapi.vote.adapter.out.persistence.CandidateCommandRedisAdapter;
+import com.kok.kokapi.vote.adapter.out.persistence.VoteKey;
 import com.kok.kokcore.room.domain.Member;
 import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.vote.domain.Candidate;
@@ -25,9 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteServiceTest extends ServiceTest {
-
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
-    private static final String VOTE_STATUS_VOTE_KEY_FORMAT = "%s:%s:%d";
 
     @Autowired
     private VoteService voteService;
@@ -65,22 +63,25 @@ class VoteServiceTest extends ServiceTest {
     @DisplayName("사용자 투표 정보를 후보별/사용자별로 모두 저장한다.")
     @Test
     void saveVotes() {
-        // given
-        String memberKey = getMemberVoteKey(room.getId(), member.getMemberId());
-        String agreeCandidateKey = getVoteStatusVoteKey(VoteStatus.AGREE, room.getId(), 1);
-        String disagreeCandidateKey = getVoteStatusVoteKey(VoteStatus.DISAGREE, room.getId(), 2);
-
         // when
         voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
 
         // then
+        String memberKey = VoteKey.memberKey(room.getId(), member.getMemberId());
+        String agreeKey = VoteKey.voteStatusMemberSetKey(
+            new Vote(candidate, member.getMemberId(), VoteStatus.AGREE));
+        String disagreeKey = VoteKey.voteStatusMemberSetKey(
+            new Vote(candidate2, member.getMemberId(), VoteStatus.DISAGREE));
+
         Map<Object, Object> storedVotes = redisTemplate.opsForHash().entries(memberKey);
-        Set<Object> agreeMemberIds = redisTemplate.opsForSet().members(agreeCandidateKey);
-        Set<Object> disagreeMemberIds = redisTemplate.opsForSet().members(disagreeCandidateKey);
+        Set<Object> agreeMemberIds = redisTemplate.opsForSet().members(agreeKey);
+        Set<Object> disagreeMemberIds = redisTemplate.opsForSet().members(disagreeKey);
 
         assertAll(
-            () -> assertThat(storedVotes).containsEntry(1L, VoteStatus.AGREE.getName()),
-            () -> assertThat(storedVotes).containsEntry(2L, VoteStatus.DISAGREE.getName()),
+            () -> assertThat(storedVotes).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "1", VoteStatus.AGREE.getName(),
+                "2", VoteStatus.DISAGREE.getName()
+            )),
             () -> assertThat(agreeMemberIds).containsExactlyInAnyOrder(member.getMemberId()),
             () -> assertThat(disagreeMemberIds).containsExactlyInAnyOrder(member.getMemberId())
         );
@@ -90,96 +91,66 @@ class VoteServiceTest extends ServiceTest {
     @Test
     void initiateBeforeSaveVote() {
         // given
-        List<Vote> votes = List.of(
-            new Vote(candidate, member.getMemberId(), VoteStatus.AGREE),
-            new Vote(candidate2, member.getMemberId(), VoteStatus.DISAGREE)
-        );
-        saveVotePort.saveAllByMember(votes);
-        for (Vote vote : votes) {
-            saveVotePort.saveByVoteStatus(vote);
-        }
+        voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
 
         // when
         voteService.saveVotes(room.getId(), member.getMemberId(), List.of());
 
         // then
-        Long storedVoteCount = redisTemplate.opsForHash()
-            .size(getMemberVoteKey(room.getId(), member.getMemberId()));
-        Long agreeCountForStation1 = redisTemplate.opsForSet()
-            .size(getVoteStatusVoteKey(VoteStatus.AGREE, room.getId(), 1));
-        Long disagreeCountForStation1 = redisTemplate.opsForSet()
-            .size(getVoteStatusVoteKey(VoteStatus.DISAGREE, room.getId(), 1));
-        Long disagreeCountForStation2 = redisTemplate.opsForSet()
-            .size(getVoteStatusVoteKey(VoteStatus.DISAGREE, room.getId(), 2));
+        String hashKey = VoteKey.memberKey(room.getId(), member.getMemberId());
+        String agreeSetKey = VoteKey.voteStatusMemberSetKey(
+            new Vote(candidate, member.getMemberId(), VoteStatus.AGREE));
+        String disagreeSetKey1 = VoteKey.voteStatusMemberSetKey(
+            new Vote(candidate, member.getMemberId(), VoteStatus.DISAGREE));
+        String disagreeSetKey2 = VoteKey.voteStatusMemberSetKey(
+            new Vote(candidate2, member.getMemberId(), VoteStatus.DISAGREE));
+
+        Long hashSize = redisTemplate.opsForHash().size(hashKey);
+        Long agreeSetSize = redisTemplate.opsForSet().size(agreeSetKey);
+        Long disagreeSetSize1 = redisTemplate.opsForSet().size(disagreeSetKey1);
+        Long disagreeSetSize2 = redisTemplate.opsForSet().size(disagreeSetKey2);
+
         assertAll(
-            () -> assertThat(storedVoteCount).isEqualTo(2),
-            () -> assertThat(agreeCountForStation1).isZero(),
-            () -> assertThat(disagreeCountForStation1).isEqualTo(1),
-            () -> assertThat(disagreeCountForStation2).isEqualTo(1)
+            () -> assertThat(hashSize).isEqualTo(2),
+            () -> assertThat(agreeSetSize).isZero(),
+            () -> assertThat(disagreeSetSize1).isEqualTo(1),
+            () -> assertThat(disagreeSetSize2).isEqualTo(1)
         );
     }
 
     @DisplayName("사용자가 투표를 완료했으면 true를 반환한다.")
     @Test
     void isVotedByMember() {
-        // given
-        Candidate candidate = new Candidate(room.getId(), 1);
-        List<Vote> votes = List.of(new Vote(candidate, member.getMemberId(), VoteStatus.AGREE));
-        saveVotePort.saveAllByMember(votes);
-        for (Vote vote : votes) {
-            saveVotePort.saveByVoteStatus(vote);
-        }
-
-        // when
+        voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
         boolean result = voteService.isVotedByMember(room.getId(), member.getMemberId());
-
-        // then
         assertThat(result).isTrue();
     }
 
     @DisplayName("사용자가 투표를 완료하지 않았으면 false를 반환한다.")
     @Test
     void isNotVotedByMember() {
-        // when
         boolean result = voteService.isVotedByMember(room.getId(), member.getMemberId());
-
-        // then
         assertThat(result).isFalse();
     }
 
     @DisplayName("방에 투표를 완료한 인원 수를 반환한다.")
     @Test
     void countVotedMembers() {
-        // given
-        List<Vote> votes = List.of(new Vote(candidate, member.getMemberId(), VoteStatus.AGREE));
-        List<Vote> votes2 = List.of(new Vote(candidate, member2.getMemberId(), VoteStatus.AGREE));
-        saveVotes(votes);
-        saveVotes(votes2);
+        voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
+        voteService.saveVotes(room.getId(), member2.getMemberId(), List.of(2L));
 
-        // when
         int count = voteService.countVotedMembers(room.getId());
 
-        // then
         assertThat(count).isEqualTo(2);
     }
 
     @DisplayName("사용자의 투표 정보를 반환한다.")
     @Test
     void getVotesByMember() {
-        // given
-        List<Vote> votes = List.of(
-            new Vote(candidate, member.getMemberId(), VoteStatus.AGREE),
-            new Vote(candidate2, member.getMemberId(), VoteStatus.DISAGREE)
-        );
-        saveVotePort.saveAllByMember(votes);
-        for (Vote vote : votes) {
-            saveVotePort.saveByVoteStatus(vote);
-        }
+        voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
 
-        // when
         List<Vote> result = voteService.getVotesByMember(room.getId(), member.getMemberId());
 
-        // then
         assertThat(result).hasSize(2)
             .extracting("stationId", "voteStatus")
             .containsExactlyInAnyOrder(
@@ -191,37 +162,24 @@ class VoteServiceTest extends ServiceTest {
     @DisplayName("특정 투표에 참여한 사용자의 정보를 반환한다.")
     @Test
     void getMembersByVote() {
-        // given
-        Vote vote = new Vote(candidate, member.getMemberId(), VoteStatus.AGREE);
-        List<Vote> votes = List.of(vote);
-        List<Vote> votes2 = List.of(new Vote(candidate, member2.getMemberId(), VoteStatus.AGREE));
-        saveVotes(votes);
-        saveVotes(votes2);
+        voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
+        voteService.saveVotes(room.getId(), member2.getMemberId(), List.of(1L));
 
-        // when
+        Vote vote = new Vote(candidate, member.getMemberId(), VoteStatus.AGREE);
+
         List<Member> result = voteService.getMembersByVote(vote);
 
-        // then
         assertThat(result).hasSize(2)
             .extracting(Member::getMemberId)
             .containsExactlyInAnyOrder(member.getMemberId(), member2.getMemberId());
     }
 
-    private void saveVotes(List<Vote> votes) {
-        saveVotePort.saveAllByMember(votes);
-        for (Vote vote : votes) {
-            saveVotePort.saveByVoteStatus(vote);
-        }
-    }
-
     @DisplayName("방이 투표 상태가 아니면 예외가 발생한다.")
     @Test
     void throwExceptionWhenRoomNotInVoteStatus() {
-        // given
         Room locationInputRoom = Room.create("inputRoom", 3, member);
         roomSaveRedisAdapter.save(locationInputRoom);
 
-        // when & then
         assertThatThrownBy(() -> voteService.countVotedMembers(locationInputRoom.getId()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("Room is not on vote status");
@@ -230,30 +188,18 @@ class VoteServiceTest extends ServiceTest {
     @DisplayName("방에 속하지 않은 멤버가 투표하면 예외가 발생한다.")
     @Test
     void throwExceptionWhenMemberNotInRoom() {
-        // given
         String nonParticipantId = "unknown";
 
-        // when & then
         assertThatThrownBy(() -> voteService.saveVotes(room.getId(), nonParticipantId, List.of()))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Cannot find member with id");
+            .hasMessageContaining("Member not found with id");
     }
 
     @DisplayName("아직 투표하지 않은 사용자가 투표 내역 조회 시 예외가 발생한다.")
     @Test
     void throwExceptionWhenGetVotesWithoutVoting() {
-        // when & then
         assertThatThrownBy(() -> voteService.getVotesByMember(room.getId(), member.getMemberId()))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Not voted by member with id");
     }
-
-    private String getMemberVoteKey(String roomId, String memberId) {
-        return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
-    }
-
-    private String getVoteStatusVoteKey(VoteStatus status, String roomId, long stationId) {
-        return String.format(VOTE_STATUS_VOTE_KEY_FORMAT, status.getName(), roomId, stationId);
-    }
 }
-

--- a/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
@@ -18,8 +18,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 class VoteServiceTest extends ServiceTest {
 
-    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:member:%s";
-    private static final String CANDIDATE_VOTE_KEY_FORMAT = "vote:%s:candidate:%d:%s";
+    private static final String MEMBER_VOTE_KEY_FORMAT = "vote:%s:%s";
+    private static final String CANDIDATE_VOTE_KEY_FORMAT = "%s:%s:%d";
 
     @Autowired
     private VoteService voteService;
@@ -39,8 +39,8 @@ class VoteServiceTest extends ServiceTest {
             new Vote(new Candidate(roomId, 2), memberId, VoteStatus.DISAGREE)
         );
         String memberKey = getMemberVoteKey(roomId, memberId);
-        String agreeCandidateKey = getCandidateVoteKey(roomId, 1, VoteStatus.AGREE);
-        String disagreeCandidateKey = getCandidateVoteKey(roomId, 2, VoteStatus.DISAGREE);
+        String agreeCandidateKey = getVoteStatusVoteKey(VoteStatus.AGREE, roomId, 1);
+        String disagreeCandidateKey = getVoteStatusVoteKey(VoteStatus.DISAGREE, roomId, 2);
 
         // when
         voteService.saveVotes(votes);
@@ -72,7 +72,7 @@ class VoteServiceTest extends ServiceTest {
         );
         saveVotePort.saveAllByMember(votes);
         for (Vote vote : votes) {
-            saveVotePort.saveByCandidate(vote);
+            saveVotePort.saveByVoteStatus(vote);
         }
         List<Vote> newVotes = List.of(
             new Vote(candidate, memberId, VoteStatus.DISAGREE),
@@ -86,11 +86,11 @@ class VoteServiceTest extends ServiceTest {
         Long storedVoteCount = redisTemplate.opsForHash()
             .size(getMemberVoteKey(roomId, memberId));
         Long agreeCountForStation1 = redisTemplate.opsForSet()
-            .size(getCandidateVoteKey(roomId, 1, VoteStatus.AGREE));
+            .size(getVoteStatusVoteKey(VoteStatus.AGREE, roomId, 1));
         Long disagreeCountForStation1 = redisTemplate.opsForSet()
-            .size(getCandidateVoteKey(roomId, 1, VoteStatus.DISAGREE));
+            .size(getVoteStatusVoteKey(VoteStatus.DISAGREE, roomId, 1));
         Long disagreeCountForStation2 = redisTemplate.opsForSet()
-            .size(getCandidateVoteKey(roomId, 2, VoteStatus.DISAGREE));
+            .size(getVoteStatusVoteKey(VoteStatus.DISAGREE, roomId, 2));
         assertAll(
             () -> assertThat(storedVoteCount).isEqualTo(2),
             () -> assertThat(agreeCountForStation1).isZero(),
@@ -109,7 +109,7 @@ class VoteServiceTest extends ServiceTest {
         List<Vote> votes = List.of(new Vote(candidate, memberId, VoteStatus.AGREE));
         saveVotePort.saveAllByMember(votes);
         for (Vote vote : votes) {
-            saveVotePort.saveByCandidate(vote);
+            saveVotePort.saveByVoteStatus(vote);
         }
 
         // when
@@ -137,8 +137,8 @@ class VoteServiceTest extends ServiceTest {
         return String.format(MEMBER_VOTE_KEY_FORMAT, roomId, memberId);
     }
 
-    private String getCandidateVoteKey(String roomId, long stationId, VoteStatus status) {
-        return String.format(CANDIDATE_VOTE_KEY_FORMAT, roomId, stationId, status.getName());
+    private String getVoteStatusVoteKey(VoteStatus status, String roomId, long stationId) {
+        return String.format(CANDIDATE_VOTE_KEY_FORMAT, status.getName(), roomId, stationId);
     }
 }
 

--- a/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
+++ b/kok-api/src/test/java/com/kok/kokapi/vote/application/service/VoteServiceTest.java
@@ -15,7 +15,6 @@ import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.vote.domain.Candidate;
 import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.domain.vo.VoteStatus;
-import com.kok.kokcore.vote.port.out.SaveVotePort;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,8 +28,6 @@ class VoteServiceTest extends ServiceTest {
 
     @Autowired
     private VoteService voteService;
-    @Autowired
-    private SaveVotePort saveVotePort;
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
     @Autowired
@@ -121,41 +118,54 @@ class VoteServiceTest extends ServiceTest {
     @DisplayName("사용자가 투표를 완료했으면 true를 반환한다.")
     @Test
     void isVotedByMember() {
+        // given
         voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
+
+        // when
         boolean result = voteService.isVotedByMember(room.getId(), member.getMemberId());
+
+        // then
         assertThat(result).isTrue();
     }
 
     @DisplayName("사용자가 투표를 완료하지 않았으면 false를 반환한다.")
     @Test
     void isNotVotedByMember() {
+        // when
         boolean result = voteService.isVotedByMember(room.getId(), member.getMemberId());
+
+        // then
         assertThat(result).isFalse();
     }
 
     @DisplayName("방에 투표를 완료한 인원 수를 반환한다.")
     @Test
     void countVotedMembers() {
+        // given
         voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
         voteService.saveVotes(room.getId(), member2.getMemberId(), List.of(2L));
 
+        // when
         int count = voteService.countVotedMembers(room.getId());
 
+        // then
         assertThat(count).isEqualTo(2);
     }
 
     @DisplayName("사용자의 투표 정보를 반환한다.")
     @Test
     void getVotesByMember() {
+        // given
         voteService.saveVotes(room.getId(), member.getMemberId(), List.of(1L));
 
+        // when
         List<Vote> result = voteService.getVotesByMember(room.getId(), member.getMemberId());
 
+        // then
         assertThat(result).hasSize(2)
-            .extracting("stationId", "voteStatus")
             .containsExactlyInAnyOrder(
-                org.assertj.core.api.Assertions.tuple(1L, VoteStatus.AGREE),
-                org.assertj.core.api.Assertions.tuple(2L, VoteStatus.DISAGREE)
+                new Vote(room.getId(), 1L, member.getMemberId(), VoteStatus.AGREE.getName()),
+                new Vote(room.getId(), 2L, member.getMemberId(), VoteStatus.DISAGREE.getName())
             );
     }
 

--- a/kok-api/src/test/resources/application-test.yml
+++ b/kok-api/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  jackson:
+    time-zone: UTC
   profiles:
     active: test
   flyway:

--- a/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
@@ -82,4 +82,8 @@ public class Room implements Serializable {
     public void closeVote() {
         this.status = RoomStatus.VOTE_RESULT;
     }
+
+    public boolean isVoteClosed() {
+        return this.status.isVoteResult();
+    }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/room/domain/vo/RoomStatus.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/domain/vo/RoomStatus.java
@@ -9,4 +9,8 @@ public enum RoomStatus {
     public boolean isLocationInput() {
         return this.equals(LOCATION_INPUT);
     }
+
+    public boolean isVoteResult() {
+        return this.equals(VOTE_RESULT);
+    }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/domain/vo/VoteStatus.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/domain/vo/VoteStatus.java
@@ -20,4 +20,8 @@ public enum VoteStatus {
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("No status with name: " + name));
     }
+
+    public boolean isAgree() {
+        return this.equals(VoteStatus.AGREE);
+    }
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/port/out/DeleteVotePort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/port/out/DeleteVotePort.java
@@ -4,7 +4,23 @@ import com.kok.kokcore.vote.domain.Vote;
 
 public interface DeleteVotePort {
 
-    void deleteByCandidate(Vote vote);
+    /**
+     * 후보지 찬/반 Set에서 memberId 제거 {agree/disagree}:{roomId}:{stationId}
+     */
+    void removeMemberFromVoteStatusSet(Vote vote);
 
-    void deleteAllByRoomIdAndMemberId(String roomId, String memberId);
+    /**
+     * 후보지 찬/반 ZSet의 투표 수(score)를 -1 {agree/disagree}:{roomId}
+     */
+    void decrementVoteCountInZSet(Vote vote);
+
+    /**
+     * member의 개인 투표 기록 삭제 member:{roomId}:{memberId}
+     */
+    void deleteMemberVoteHash(String roomId, String memberId);
+
+    /**
+     * vote 완료 Set에서 memberId 제거 ex) vote:{roomId}
+     */
+    void removeMemberFromVotedSet(String roomId, String memberId);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/port/out/LoadVotePort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/port/out/LoadVotePort.java
@@ -1,6 +1,7 @@
 package com.kok.kokcore.vote.port.out;
 
 import com.kok.kokcore.vote.domain.Vote;
+import com.kok.kokcore.vote.domain.vo.VoteStatus;
 import java.util.List;
 
 public interface LoadVotePort {
@@ -8,4 +9,6 @@ public interface LoadVotePort {
     boolean isExistsByRoomIdAndMemberId(String roomId, String memberId);
 
     List<Vote> findAllByRoomIdAndMemberId(String roomId, String memberId);
+
+    long getFirstStationIdByRoomIdAndVoteStatus(String roomId, VoteStatus voteStatus);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/port/out/SaveVotePort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/port/out/SaveVotePort.java
@@ -5,7 +5,11 @@ import java.util.List;
 
 public interface SaveVotePort {
 
-    void saveByVoteStatus(Vote vote);
+    void saveVoteMemberHash(List<Vote> votes);
 
-    void saveAllByMember(List<Vote> votes);
+    void saveVoteStatusSet(Vote vote);
+
+    void incrementVoteStatusCountZSet(Vote vote);
+
+    void saveVotedMemberSet(String roomId, String memberId);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/port/out/SaveVotePort.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/port/out/SaveVotePort.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface SaveVotePort {
 
-    void saveByCandidate(Vote vote);
+    void saveByVoteStatus(Vote vote);
 
     void saveAllByMember(List<Vote> votes);
 }

--- a/kok-core/src/main/java/com/kok/kokcore/vote/usecase/GetVoteUseCase.java
+++ b/kok-core/src/main/java/com/kok/kokcore/vote/usecase/GetVoteUseCase.java
@@ -1,6 +1,10 @@
 package com.kok.kokcore.vote.usecase;
 
+import com.kok.kokcore.station.domain.entity.Station;
+
 public interface GetVoteUseCase {
 
     boolean isVotedByMember(String roomId, String memberId);
+
+    Station getVoteFinalResult(String roomId);
 }


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
- #96 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 투표 redis 자료구조에 크게 변경사항이 있습니다.

기능 | 키 포맷 | 설명
-- | -- | --
회원별 투표 결과 | member:{roomId}:{memberId} | Hash: {stationId} → AGREE/DISAGREE
찬성/반대 멤버 리스트 | agree/disagree:{roomId}:{stationId} | Set: memberIds
찬성/반대 투표수 | agree/disagree:{roomId} | ZSet: stationId → count
투표 완료자 목록 | vote:{roomId} | Set: memberIds

- 찬성 투표가 제일 많은 지하철역을 반환하는 기능을 구현했습니다.
- 시간은 UTC 시간을 사용할 수 있도록 yml에 설정해두었습니다.
- 투표 후보지 조회 측에서 대중교통 정보를 조회할 수 없을 경우, TransportationParsedResponse가 null을 반환하는 에러를 해결했습니다.
- 투표 후보지 조회 API에 서버 추천/사용자 추가 후보지를 구분하기 위한 `isKokRecommended` boolean 필드를 추가했습니다.
- 사용자별 투표 상태 조회 API에 사용자 주소 정보를 응답 필드로 추가했습니다.

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
