### PR TITLE
:bug: [Fix/room] fix save room add logging for redis template

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomParticipantSaveAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomParticipantSaveAdapter.java
@@ -2,12 +2,15 @@ package com.kok.kokapi.room.adapter.out.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kok.kokapi.common.util.RedisExecutor;
 import com.kok.kokcore.room.domain.Member;
 import com.kok.kokcore.room.port.out.SaveRoomParticipantsPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RoomParticipantSaveAdapter implements SaveRoomParticipantsPort {
@@ -22,12 +25,17 @@ public class RoomParticipantSaveAdapter implements SaveRoomParticipantsPort {
 
         try {
             String memberJson = objectMapper.writeValueAsString(member);
-            redisTemplate.opsForList().rightPush(key, memberJson);
-
-            Long participantCount = redisTemplate.opsForList().size(key);
+            RedisExecutor.runOrThrow("joinRoom:push" + roomId,
+                () -> redisTemplate.opsForList().rightPush(key, memberJson));
+            Long participantCount = RedisExecutor.runOrThrow("joinRoom:size: " + roomId,
+                () -> redisTemplate.opsForList().size(key));
             return participantCount != null ? participantCount.intValue() : 0;
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("failed to serialize member");
+            log.error("[RoomParticipant] Failed to serialize member. roomId={}, member={}", roomId, member, e);
+            throw new RuntimeException("Failed to serialize member", e);
+        } catch (Exception e) {
+            log.error("[RoomParticipant] Redis join failed. roomId={}, member={}", roomId, member, e);
+            throw new RuntimeException("Failed to join room in Redis: " + e.getClass().getSimpleName(), e);
         }
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
@@ -2,14 +2,17 @@ package com.kok.kokapi.room.adapter.out.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kok.kokapi.common.util.RedisExecutor;
 import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.room.port.out.SaveRoomPort;
 import com.kok.kokcore.room.port.out.UpdateRoomPort;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
@@ -25,9 +28,14 @@ public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
         String key = buildKey(room.getId());
         try {
             String roomJson = objectMapper.writeValueAsString(room);
-            redisTemplate.opsForValue().set(key, roomJson, ROOM_TTL);
+            RedisExecutor.runOrThrow("saveRoom",
+                () -> redisTemplate.opsForValue().set(key, roomJson, ROOM_TTL));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("failed to save room to Redis", e);
+            log.error("[Room] Failed to serialize room. roomId={}", room.getId(), e);
+            throw new RuntimeException("failed to serialize room object", e);
+        } catch (Exception e) {
+            log.error("[Room] Save to Redis failed. roomId={}, key={}", room.getId(), key, e);
+            throw new RuntimeException("failed to save room to Redis: " + e.getClass().getSimpleName(), e);
         }
         return room;
     }
@@ -41,7 +49,11 @@ public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
 
             redisTemplate.opsForValue().set(key, roomJson, currentTtl);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("failed to update room in Redis", e);
+            log.error("[Room] Failed to serialize room. roomId={}", room.getId(), e);
+            throw new RuntimeException("failed to serialize room object", e);
+        } catch (RuntimeException e) {
+            log.error("[Room] update to Redis failed. roomId={}, key={}", room.getId(), key, e);
+            throw new RuntimeException("failed to update room in Redis: " + e.getClass().getSimpleName(), e);
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #

## 📝 작업 내용
- 간헐적인 약속방 생성 실패로 500 에러 발생
- 약속방에서 입력값 검증이나 직렬화 과정에서 json parsing 오류는 예외 처리가 되어 있음
- save 로직 혹은 join 로직에서 redis 저장 시 connection error 등으로 500 에러가 발생하면 기존에는 GlobalExceptionHandler와 ApiResonseDto에서 처리하면서 `{ code: 500, message: null, data: null }`로 처리되고 swagger 상에서는 message가 null이다보니 place holder로 text를 표시해주어서 에러 확인이 어려움
- 로깅을 추가해서 약속방 생성 실패 시 로그 확인이 가능하도록 개선
- 기존에 만들어진 RedisExecutor를 이용해서 Redis 예외에 대한 상세한 예외 처리를 적용

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
