### PR TITLE
🐛 [Fix/Room] fix timezone error and add safety code for getting expire ttl

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/config/time/TimeZoneConfig.java
+++ b/kok-api/src/main/java/com/kok/kokapi/config/time/TimeZoneConfig.java
@@ -1,0 +1,16 @@
+package com.kok.kokapi.config.time;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        System.out.println("Set JVM default timezone to UTC");
+    }
+}
+

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
@@ -8,10 +8,12 @@ import com.kok.kokcore.room.port.out.UpdateRoomPort;
 import java.time.Duration;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Slf4j
 @RequiredArgsConstructor
 public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
 
@@ -52,6 +54,7 @@ public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
     private Duration getTTL(String key) {
         Long expireSeconds = redisTemplate.getExpire(key);
         if (Objects.isNull(expireSeconds) || expireSeconds <= 0) {
+            log.warn("Cannot find key: {}, initiate expire TTL", key);
             return ROOM_TTL;
         }
         return Duration.ofSeconds(expireSeconds);

--- a/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/room/adapter/out/persistence/RoomSaveRedisAdapter.java
@@ -6,6 +6,7 @@ import com.kok.kokcore.room.domain.Room;
 import com.kok.kokcore.room.port.out.SaveRoomPort;
 import com.kok.kokcore.room.port.out.UpdateRoomPort;
 import java.time.Duration;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -37,8 +38,7 @@ public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
         String key = buildKey(room.getId());
         try {
             String roomJson = objectMapper.writeValueAsString(room);
-            Duration currentTtl = Duration.ofSeconds(redisTemplate.getExpire(key));
-
+            Duration currentTtl = getTTL(key);
             redisTemplate.opsForValue().set(key, roomJson, currentTtl);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("failed to update room in Redis", e);
@@ -47,5 +47,13 @@ public class RoomSaveRedisAdapter implements SaveRoomPort, UpdateRoomPort {
 
     private String buildKey(String roomId) {
         return ROOM_KEY_PREFIX + ":" + roomId;
+    }
+
+    private Duration getTTL(String key) {
+        Long expireSeconds = redisTemplate.getExpire(key);
+        if (Objects.isNull(expireSeconds) || expireSeconds <= 0) {
+            return ROOM_TTL;
+        }
+        return Duration.ofSeconds(expireSeconds);
     }
 }

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/VoteDeadlineResponse.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/dto/response/VoteDeadlineResponse.java
@@ -1,9 +1,14 @@
 package com.kok.kokapi.vote.adapter.in.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kok.kokcore.room.domain.Room;
 import java.time.LocalDateTime;
 
-public record VoteDeadlineResponse(int candidateCount, LocalDateTime endAt) {
+public record VoteDeadlineResponse(
+    int candidateCount,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    LocalDateTime endAt
+) {
 
     public static VoteDeadlineResponse of(Room room, int candidateCount) {
         return new VoteDeadlineResponse(candidateCount, room.getVoteLimitDateTime());

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/in/web/VoteController.java
@@ -66,7 +66,7 @@ public class VoteController {
         return ResponseEntity.ok(ApiResponseDto.success(responses));
     }
 
-    @Operation(summary = "투표 마감 시간 조회", description = "방 ID에 대한 투표 마감 시간(UTC)을 조회합니다.")
+    @Operation(summary = "투표 마감 시간 조회", description = "방 ID에 대한 투표 마감 시간을 조회합니다.")
     @GetMapping("/votes/{roomId}/deadline")
     public ResponseEntity<ApiResponseDto<VoteDeadlineResponse>> getVoteDeadline(
         @PathVariable String roomId) {

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
@@ -105,6 +105,7 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
     private Duration getTTL(String key) {
         Long expireSeconds = redisTemplate.getExpire(key);
         if (Objects.isNull(expireSeconds) || expireSeconds <= 0) {
+            log.warn("Cannot find key: {}, initiate expire TTL", key);
             return VOTE_TTL;
         }
         return Duration.ofSeconds(expireSeconds);

--- a/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/adapter/out/persistence/VoteCommandRedisAdapter.java
@@ -4,6 +4,7 @@ import com.kok.kokapi.common.util.RedisExecutor;
 import com.kok.kokcore.vote.domain.Vote;
 import com.kok.kokcore.vote.port.out.DeleteVotePort;
 import com.kok.kokcore.vote.port.out.SaveVotePort;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
+
+    private static final Duration VOTE_TTL = Duration.ofDays(3);
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -30,31 +33,35 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
                 String status = vote.getVoteStatus().getName();
                 redisTemplate.opsForHash().put(memberHashKey, field, status);
             }
+            redisTemplate.expire(memberHashKey, getTTL(memberHashKey));
         });
     }
 
     @Override
     public void saveVotedMemberSet(String roomId, String memberId) {
         String votedMemberSetKey = VoteKey.voteKey(roomId);
-        RedisExecutor.runOrThrow("saveVotedMemberSet", () ->
-            redisTemplate.opsForSet().add(votedMemberSetKey, memberId)
-        );
+        RedisExecutor.runOrThrow("saveVotedMemberSet", () -> {
+            redisTemplate.opsForSet().add(votedMemberSetKey, memberId);
+            redisTemplate.expire(votedMemberSetKey, getTTL(votedMemberSetKey));
+        });
     }
 
     @Override
     public void saveVoteStatusSet(Vote vote) {
         String key = VoteKey.voteStatusMemberSetKey(vote);
-        RedisExecutor.runOrThrow("saveVoteStatusSet", () ->
-            redisTemplate.opsForSet().add(key, vote.getMemberId())
-        );
+        RedisExecutor.runOrThrow("saveVoteStatusSet", () -> {
+            redisTemplate.opsForSet().add(key, vote.getMemberId());
+            redisTemplate.expire(key, getTTL(key));
+        });
     }
 
     @Override
     public void incrementVoteStatusCountZSet(Vote vote) {
         String key = VoteKey.voteStatusCountZSetKey(vote);
-        RedisExecutor.runOrThrow("incrementVoteStatusCountZSet", () ->
-            redisTemplate.opsForZSet().incrementScore(key, vote.getStationId(), 1)
-        );
+        RedisExecutor.runOrThrow("incrementVoteStatusCountZSet", () -> {
+            redisTemplate.opsForZSet().incrementScore(key, vote.getStationId(), 1);
+            redisTemplate.expire(key, getTTL(key));
+        });
     }
 
     private void validate(List<Vote> votes) {
@@ -93,5 +100,13 @@ public class VoteCommandRedisAdapter implements SaveVotePort, DeleteVotePort {
         RedisExecutor.runOrThrow("removeMemberFromVotedSet", () ->
             redisTemplate.opsForSet().remove(key, memberId)
         );
+    }
+
+    private Duration getTTL(String key) {
+        Long expireSeconds = redisTemplate.getExpire(key);
+        if (Objects.isNull(expireSeconds) || expireSeconds <= 0) {
+            return VOTE_TTL;
+        }
+        return Duration.ofSeconds(expireSeconds);
     }
 }

--- a/kok-api/src/main/resources/application-dev.yml
+++ b/kok-api/src/main/resources/application-dev.yml
@@ -1,6 +1,4 @@
 spring:
-  jackson:
-    time-zone: UTC
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/kok-api/src/main/resources/application-prod.yml
+++ b/kok-api/src/main/resources/application-prod.yml
@@ -1,6 +1,4 @@
 spring:
-  jackson:
-    time-zone: UTC
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/kok-api/src/test/resources/application-test.yml
+++ b/kok-api/src/test/resources/application-test.yml
@@ -1,6 +1,4 @@
 spring:
-  jackson:
-    time-zone: UTC
   profiles:
     active: test
   flyway:

--- a/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
@@ -32,8 +32,10 @@ public class Room implements Serializable {
         this.capacity = capacity;
         this.member = member;
         this.createdDateTime = LocalDateTime.now().withNano(0);
-        this.locationInputLimitDateTime = createdDateTime.plusHours(LOCATION_INPUT_TIME_LIMIT);
-        this.voteLimitDateTime = locationInputLimitDateTime.plusHours(VOTE_TIME_LIMIT);
+        this.locationInputLimitDateTime = createdDateTime.plusHours(LOCATION_INPUT_TIME_LIMIT)
+            .withNano(0);
+        this.voteLimitDateTime = locationInputLimitDateTime.plusHours(VOTE_TIME_LIMIT)
+            .withNano(0);
         this.status = RoomStatus.LOCATION_INPUT;
     }
 

--- a/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
+++ b/kok-core/src/main/java/com/kok/kokcore/station/domain/entity/Route.java
@@ -36,12 +36,14 @@ public class Route {
         Map.entry("경인선", "1호선"),
         Map.entry("경원선", "1호선"),
         Map.entry("장항선", "1호선"),
+        Map.entry("과천선", "4호선"),
+        Map.entry("7호선(인천)", "7호선"),
+        Map.entry("9호선(연장)", "9호선"),
         Map.entry("신분당선(연장)", "신분당선"),
         Map.entry("신분당선(연장2)", "신분당선"),
-        Map.entry("9호선(연장)", "9호선"),
-        Map.entry("7호선(인천)", "7호선"),
         Map.entry("수인선", "수인분당선"),
         Map.entry("분당선", "수인분당선"),
+        Map.entry("안산선", "수인분당선"),
         Map.entry("수도권 광역급행철도", "GTX"),
         Map.entry("공항철도1호선", "공항철도")
     );

--- a/kok-core/src/test/java/com/kok/kokcore/station/port/out/dto/StationRouteDtosTest.java
+++ b/kok-core/src/test/java/com/kok/kokcore/station/port/out/dto/StationRouteDtosTest.java
@@ -85,12 +85,12 @@ class StationRouteDtosTest {
         List<Route> routes = stationRouteDtos.toRoutesByStations(List.of(station1, station2));
 
         // then
-        List<Long> codes = routes.stream().map(Route::getCode).toList();
+        List<String> names = routes.stream().map(Route::getName).toList();
         List<Station> stations = routes.stream().map(Route::getStation).distinct().toList();
 
         assertAll(
             () -> assertThat(routes).hasSize(3),
-            () -> assertThat(codes).containsExactlyInAnyOrder(1L, 2L, 3L),
+            () -> assertThat(names).containsExactlyInAnyOrder("1호선", "2호선", "신분당선"),
             () -> assertThat(stations).containsExactlyInAnyOrder(station1, station2)
         );
     }


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
- #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 새벽에 시연 도중, 드물게 방 정보가 삭제되어버리는 문제를 발견했습니다.
- 원인을 분석해보려고 시도했지만, 명확한 원인은 아직 찾지 못했습니다.
- 직접적으로 key를 삭제하는 로직은 따로 없기 때문에 값 수정 시 기존 TTL 정보를 조회해서 수정하는 부분에서 방어 코드를 추가했습니다. 현재로서 의심가는 지점은 TTL 조회 시도 시 의도치 않게 TTL을 찾지 못해 즉시 만료되는 부분이라서 방어 코드를 추가하고, 우선은 로그를 남겨 모니터링해봐야 할 것 같습니다.
- 서버, redis는 timezone으로 UTC를, 응답 반환 시에는 KST를 사용하도록 수정했습니다.
- 추가적인 지하철역 이름 변환 요청이 있어 반영했습니다.
### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
