### PR TITLE
:bug: [Feature/vote] fix room status validation error due to wrong condition

### DIFF
--- a/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
+++ b/kok-api/src/main/java/com/kok/kokapi/vote/application/service/VoteService.java
@@ -98,7 +98,7 @@ public class VoteService implements SaveVoteUseCase, GetVoteUseCase {
 
     private void validateRoomStatusIfBeforeVote(String roomId) {
         Room room = getRoom(roomId);
-        if (room.isNotOnVote()) {
+        if (room.isBeforeVote()) {
             throw new IllegalStateException(
                 "Room is not on vote yet, but status: " + room.getStatus());
         }

--- a/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
+++ b/kok-core/src/main/java/com/kok/kokcore/room/domain/Room.java
@@ -61,6 +61,10 @@ public class Room implements Serializable {
             || current.isAfter(locationInputLimitDateTime));
     }
 
+    public boolean isBeforeVote() {
+        return this.status.isLocationInput();
+    }
+
     public boolean isNotOnVote() {
         return this.status.isLocationInput() || this.status.isVoteResult();
     }


### PR DESCRIPTION
…ted instead not on vote

<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
- #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 투표 전인지 확인하는 유효성 검증에서 `isBeforeVote()`가 아닌 투표 중임을 확인하는 `isNotOnVote()`를 호출하고 있어 버그가 발생했습니다.
### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
